### PR TITLE
Fix TypeError: can only concatenate tuple (not list) to tuple

### DIFF
--- a/framework/src/services.py
+++ b/framework/src/services.py
@@ -589,7 +589,7 @@ class ServicesProxy(object):
         .. note :: This is a nonblocking function, users must use a version of :py:meth:`ServicesProxy.wait_task` to get result.
 
         """
-        args = [str(a) for a in args]
+        args = tuple(str(a) for a in args)
         tokens = binary.split()
         if len(tokens) > 1:
             binary = tokens[0]


### PR DESCRIPTION
```
  File framework/src/services.py, line 596, in launch_task
    args = tuple(tokens[1:]) + args
TypeError: can only concatenate tuple (not list) to tuple
```