### PR TITLE
Fix hang when required parameters are missing in config

### DIFF
--- a/ipsframework/configurationManager.py
+++ b/ipsframework/configurationManager.py
@@ -580,10 +580,10 @@ class ConfigurationManager:
                 else:
                     comp_conf['BIN_PATH'] = comp_conf['BIN_DIR']
             if (not self.required_fields.issubset(conf_fields)):
-                self.fwk.exception('Error: missing required entries %s \
-                    in simulation %s component %s configuration section',
-                                   list(self.required_fields - conf_fields), sim_name, comp_ref)
-                sys.exit(1)
+                msg = 'Error: missing required entries {} in simulation {} component {} configuration section'.format(
+                    list(self.required_fields - conf_fields), sim_name, comp_ref)
+                self.fwk.critical(msg)
+                raise RuntimeError(msg)
             component_id = self._create_component(comp_conf, sim_data)
             sim_data.port_map[port] = component_id
             if (port == 'DRIVER'):
@@ -592,9 +592,9 @@ class ConfigurationManager:
                 sim_data.init_comp = component_id
 
         if (sim_data.driver_comp is None):
-            self.fwk.error('Missing DRIVER specification in ' +
-                           'config file for simulation %s', sim_data.sim_name)
-            sys.exit(1)
+            msg = 'Missing DRIVER specification in config file for simulation {}'.format(sim_data.sim_name)
+            self.fwk.critical(msg)
+            raise RuntimeError(msg)
         if (sim_data.init_comp is None):
             self.fwk.warning('Missing INIT specification in ' +
                              'config file for simulation %s', sim_data.sim_name)

--- a/ipsframework/ips.py
+++ b/ipsframework/ips.py
@@ -762,9 +762,10 @@ class Framework:
             try:
                 portal_data['rcomment'] = get_config(sim_name, 'SIMULATION_DESCRIPTION')
             except KeyError:
-                portal_data['rcomment'] = get_config(sim_name, 'RUN_COMMENT')
-            except KeyError:
-                portal_data['rcomment'] = 'SWIM simulation run'
+                try:
+                    portal_data['rcomment'] = get_config(sim_name, 'RUN_COMMENT')
+                except KeyError:
+                    portal_data['rcomment'] = 'SWIM simulation run'
             try:
                 portal_data['tokamak'] = get_config(sim_name, 'TOKAMAK_ID')
             except KeyError:


### PR DESCRIPTION
If a DRIVER PORT is not-specfied you will get an error like "ERROR    Missing DRIVER ..." but ips.py never exits.

The same is if one of the require parameters for a PORT is missing, "ERROR    Error: missing required entries ..." but ips.py never exits.

This fixes the issue by instead of doing sys.exit it raise a RuntimeError in these cases