### PR TITLE
Fix service log calls

### DIFF
--- a/ipsframework/configurationManager.py
+++ b/ipsframework/configurationManager.py
@@ -40,11 +40,7 @@ class ConfigurationManager:
             self.all_comps = []
             self.port_map = {}
             self.component_process = None
-            self.log_file = None
-            self.log_pipe_name = None
-            self.logger = None
             self.process_list = []
-            self.fwk_logger = None
 
     def __init__(self, fwk, config_file_list, platform_file_name):
         """
@@ -336,11 +332,6 @@ class ConfigurationManager:
                 self.fwk.exception('Invalid LOG_LEVEL value %s in config file %s ',
                                    log_level, conf_file)
                 raise
-            socketHandler = ipsLogging.IPSLogSocketHandler(new_sim.log_pipe_name)
-            new_sim.fwk_logger = logging.getLogger(sim_name + '_FRAMEWORK')
-            new_sim.fwk_logger.setLevel(real_log_level)
-            new_sim.fwk_logger.addHandler(socketHandler)
-            # SEK: It'd be nice to log to the zip file but I don't understand the handles
 
             # Use first simulation for framework components
             if not self.fwk_sim_name:

--- a/ipsframework/configurationManager.py
+++ b/ipsframework/configurationManager.py
@@ -321,17 +321,6 @@ class ConfigurationManager:
             self.log_daemon.add_sim_log(new_sim.log_pipe_name,
                                         new_sim.log_file)
             self.sim_map[sim_name] = new_sim
-            log_level = 'DEBUG'
-            try:
-                log_level = conf['LOG_LEVEL']
-            except KeyError:
-                pass
-            try:
-                real_log_level = getattr(logging, log_level)
-            except AttributeError:
-                self.fwk.exception('Invalid LOG_LEVEL value %s in config file %s ',
-                                   log_level, conf_file)
-                raise
 
             # Use first simulation for framework components
             if not self.fwk_sim_name:

--- a/ipsframework/ips.py
+++ b/ipsframework/ips.py
@@ -344,7 +344,7 @@ class Framework:
                 msg = args[0] % args[1:]
             else:
                 msg = args[0]
-            self.logger.exception(msg)
+            self.logger.exception(msg, exc_info=False)
         except Exception:
             self.error('Bad format in call to fwk.exception() ' + str(args))
 

--- a/ipsframework/ipsLogging.py
+++ b/ipsframework/ipsLogging.py
@@ -3,13 +3,11 @@ This file implements several objects that customize logging in the IPS.
 """
 
 import logging
-import logging.handlers
 import sys
 import pickle
 import socketserver
 import struct
 import functools
-import socket
 import os
 import os.path
 import queue
@@ -33,20 +31,6 @@ def list_fds():
         ret[int(num)] = path
 
     return ret
-
-
-class IPSLogSocketHandler(logging.handlers.SocketHandler):
-    def __init__(self, port):
-        logging.handlers.SocketHandler.__init__(self, None, None)
-        self.host = None
-        self.port = port
-        self.my_socket = None
-
-    def makeSocket(self, timeout=1):
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        s.connect(self.port)
-        self.my_socket = s
-        return self.my_socket
 
 
 class myLogRecordStreamHandler(socketserver.StreamRequestHandler):
@@ -135,7 +119,6 @@ class ipsLogger:
                         sys.exit(1)
                 log_handler = logging.FileHandler(log_file, mode='w')
 
-#        log_handler.setLevel(logging.DEBUG)
         log_handler.setFormatter(self.formatter)
         partial_handler = functools.partial(myLogRecordStreamHandler,
                                             handler=log_handler)

--- a/ipsframework/ipsLogging.py
+++ b/ipsframework/ipsLogging.py
@@ -48,10 +48,10 @@ class myLogRecordStreamHandler(socketserver.StreamRequestHandler):
         followed by the LogRecord in pickle format. Logs the record
         according to whatever policy is configured locally.
         """
-        try:
+        while True:
             chunk = self.connection.recv(4)
             if len(chunk) < 4:
-                return
+                break
             slen = struct.unpack(">L", chunk)[0]
             chunk = self.connection.recv(slen)
             while len(chunk) < slen:
@@ -59,8 +59,6 @@ class myLogRecordStreamHandler(socketserver.StreamRequestHandler):
             obj = self.unPickle(chunk)
             record = logging.makeLogRecord(obj)
             self.handleLogRecord(record)
-        except Exception:
-            pass
 
     def unPickle(self, data):
         return pickle.loads(data)

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -9,11 +9,12 @@ import subprocess
 import time
 import shutil
 import logging
+import logging.handlers
 import signal
 import glob
 import weakref
 import inspect
-from . import messages, ipsutil, ipsLogging, component
+from . import messages, ipsutil, component
 from .configobj import ConfigObj
 from .cca_es_spec import initialize_event_service
 from .ips_es_spec import eventManager
@@ -161,7 +162,7 @@ class ServicesProxy:
         #
         # Set up logging path to the IPS logging daemon
         #
-        socketHandler = ipsLogging.IPSLogSocketHandler(self.log_pipe_name)
+        socketHandler = logging.handlers.SocketHandler(self.log_pipe_name, None)
         self.logger = logging.getLogger(self.full_comp_id)
         log_level = 'WARNING'
         try:

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2178,7 +2178,7 @@ class ServicesProxy:
         """
         Wrapper for :py:meth:`ServicesProxy.info`.
         """
-        return self.info(args)
+        return self.info(*args)
 
     def debug(self, *args):
         """
@@ -2241,7 +2241,7 @@ class ServicesProxy:
                 msg = args[0] % args[1:]
             else:
                 msg = args[0]
-            self.logger.exception(msg)
+            self.logger.exception(msg, exc_info=False)
         except Exception:
             self.error('Bad format in call to services.exception() ' + str(args))
 

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -9,7 +9,6 @@ import subprocess
 import time
 import shutil
 import logging
-import logging.handlers
 import signal
 import glob
 import weakref

--- a/tests/components/drivers/logging_tester.py
+++ b/tests/components/drivers/logging_tester.py
@@ -1,0 +1,24 @@
+from ipsframework import Component
+
+log_types = ["log",
+             "debug",
+             "info",
+             "warning",
+             "error",
+             "exception",
+             "critical"]
+
+
+class logging_tester(Component):
+
+    def init(self, timestamp):
+        for log_type in log_types:
+            getattr(self.services, log_type)(f'init msg: {log_type}')
+
+    def step(self, timestamp):
+        for log_type in log_types:
+            getattr(self.services, log_type)(f'step msg: {log_type}')
+
+    def finalize(self, timestamp):
+        for log_type in log_types:
+            getattr(self.services, log_type)(f'finalize msg: {log_type}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,16 @@
 import pytest
 import psutil
 import os
+from ipsframework.componentRegistry import ComponentID
 
 
 @pytest.fixture(autouse=True)
 def run_around_tests():
+    # Reset the ComponentID.seq_num so that each test is independent
+    ComponentID.seq_num = 0
+
     yield
+
     # if an assert fails then not all the children may close and the
     # test will hang, so kill all the children
     children = psutil.Process(os.getpid()).children()

--- a/tests/new/test_component_logging.py
+++ b/tests/new/test_component_logging.py
@@ -1,0 +1,124 @@
+from ipsframework import Framework
+
+
+map_log_to_level = {"log": "INFO",
+                    "debug": "DEBUG",
+                    "info": "INFO",
+                    "warning": "WARNING",
+                    "error": "ERROR",
+                    "exception": "ERROR",
+                    "critical": "CRITICAL"}
+
+
+def write_basic_config_and_platform_files(tmpdir, debug=False):
+    platform_file = tmpdir.join('platform.conf')
+
+    platform = """MPIRUN = eval
+NODE_DETECTION = manual
+CORES_PER_NODE = 1
+SOCKETS_PER_NODE = 1
+NODE_ALLOCATION_MODE = shared
+HOST =
+SCRATCH =
+"""
+
+    with open(platform_file, 'w') as f:
+        f.write(platform)
+
+    config_file = tmpdir.join('ips.config')
+
+    log_level = "DEBUG" if debug else "WARNING"
+
+    config = f"""RUN_COMMENT = testing
+SIM_NAME = test
+LOG_FILE = {str(tmpdir)}/sim.log
+LOG_LEVEL = {log_level}
+SIM_ROOT = {str(tmpdir)}
+SIMULATION_MODE = NORMAL
+[PORTS]
+    NAMES = DRIVER
+    [[DRIVER]]
+      IMPLEMENTATION = LOGGING_DRIVER
+[LOGGING_DRIVER]
+    CLASS = LOGGING
+    SUB_CLASS =
+    NAME = logging_tester
+    BIN_PATH =
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    SCRIPT =
+    MODULE = components.drivers.logging_tester
+"""
+
+    with open(config_file, 'w') as f:
+        f.write(config)
+
+    return platform_file, config_file
+
+
+def test_component_logging(tmpdir, capfd):
+    platform_file, config_file = write_basic_config_and_platform_files(tmpdir)
+
+    framework = Framework(config_file_list=[str(config_file)],
+                          log_file_name=str(tmpdir.join('ips.log')),
+                          platform_file_name=str(platform_file),
+                          debug=None,
+                          verbose_debug=None,
+                          cmd_nodes=0,
+                          cmd_ppn=0)
+
+    framework.run()
+
+    # check output log file
+    with open(str(tmpdir.join('sim.log')), 'r') as f:
+        lines = f.readlines()
+
+    # remove timestamp
+    lines = [line[24:] for line in lines]
+
+    component_id = "LOGGING__logging_tester_1"
+
+    # for log_level=WARNING only WARNING, ERROR and CRITICAL logs should be included
+    # DEBUG and INFO should be excluded
+    for method in ["init", "step", "finalize"]:
+        for log_type in ["warning", "error", "exception", "critical"]:
+            assert f'{component_id} {map_log_to_level[log_type]:8} {method} msg: {log_type}\n' in lines
+        for log_type in ["log", "debug", "info"]:
+            assert f'{component_id} {map_log_to_level[log_type]:8} {method} msg: {log_type}\n' not in lines
+
+
+def test_component_logging_debug(tmpdir):
+    platform_file, config_file = write_basic_config_and_platform_files(tmpdir, debug=True)
+
+    framework = Framework(config_file_list=[str(config_file)],
+                          log_file_name=str(tmpdir.join('ips.log')),
+                          platform_file_name=str(platform_file),
+                          debug=None,
+                          verbose_debug=None,
+                          cmd_nodes=0,
+                          cmd_ppn=0)
+
+    framework.run()
+
+    # check output log file
+    with open(str(tmpdir.join('sim.log')), 'r') as f:
+        lines = f.readlines()
+
+    # remove timestamp
+    lines = [line[24:] for line in lines]
+
+    map_log_to_level = {"log": "INFO",
+                        "debug": "DEBUG",
+                        "info": "INFO",
+                        "warning": "WARNING",
+                        "error": "ERROR",
+                        "exception": "ERROR",
+                        "critical": "CRITICAL"}
+
+    component_id = "LOGGING__logging_tester_1"
+
+    # for log_level=DEBUG all logs should be included
+    for method in ["init", "step", "finalize"]:
+        for log_type in ["log", "debug", "info", "warning", "error", "exception", "critical"]:
+            assert f'{component_id} {map_log_to_level[log_type]:8} {method} msg: {log_type}\n' in lines

--- a/tests/new/test_helloworld.py
+++ b/tests/new/test_helloworld.py
@@ -59,7 +59,7 @@ def test_helloworld(tmpdir, capfd):
     assert len(hello_world_1) == 1
     assert hello_world_1[0].get_class_name() == 'HelloDriver'
     assert hello_world_1[0].get_instance_name().startswith('Hello_world_1@HelloDriver')
-    # assert hello_world_1[0].get_seq_num() == 1 # need to find a way to reset static variable
+    assert hello_world_1[0].get_seq_num() == 1
     assert hello_world_1[0].get_serialization().startswith('Hello_world_1@HelloDriver')
     assert hello_world_1[0].get_sim_name() == 'Hello_world_1'
 
@@ -109,7 +109,7 @@ def test_helloworld_task_pool(tmpdir, capfd):
     assert len(hello_world_1) == 1
     assert hello_world_1[0].get_class_name() == 'HelloDriver'
     assert hello_world_1[0].get_instance_name().startswith('Hello_world_1@HelloDriver')
-    # assert hello_world_1[0].get_seq_num() == 1 # need to find a way to reset static variable
+    assert hello_world_1[0].get_seq_num() == 1
     assert hello_world_1[0].get_serialization().startswith('Hello_world_1@HelloDriver')
     assert hello_world_1[0].get_sim_name() == 'Hello_world_1'
 
@@ -162,8 +162,8 @@ def test_helloworld_portal(tmpdir, capfd):
 
     fwk_components = framework.config_manager.get_framework_components()
     assert len(fwk_components) == 2
-    assert 'Hello_world_1_FWK@runspaceInitComponent@11' in fwk_components
-    assert 'Hello_world_1_FWK@PortalBridge@12' in fwk_components
+    assert 'Hello_world_1_FWK@runspaceInitComponent@3' in fwk_components
+    assert 'Hello_world_1_FWK@PortalBridge@4' in fwk_components
 
     component_map = framework.config_manager.get_component_map()
 
@@ -173,7 +173,7 @@ def test_helloworld_portal(tmpdir, capfd):
     assert len(hello_world_1) == 1
     assert hello_world_1[0].get_class_name() == 'HelloDriver'
     assert hello_world_1[0].get_instance_name().startswith('Hello_world_1@HelloDriver')
-    # assert hello_world_1[0].get_seq_num() == 1 # need to find a way to reset static variable
+    assert hello_world_1[0].get_seq_num() == 1
     assert hello_world_1[0].get_serialization().startswith('Hello_world_1@HelloDriver')
     assert hello_world_1[0].get_sim_name() == 'Hello_world_1'
 

--- a/tests/new/test_ips_framework.py
+++ b/tests/new/test_ips_framework.py
@@ -83,7 +83,7 @@ def test_framework_simple(tmpdir, capfd):
     assert len(test) == 1
     assert test[0].get_class_name() == 'test_driver'
     assert test[0].get_instance_name().startswith('test@test_driver')
-    # assert test[0].get_seq_num() == 1 # need to find a way to reset static variable
+    assert test[0].get_seq_num() == 1
     assert test[0].get_serialization().startswith('test@test_driver')
     assert test[0].get_sim_name() == 'test'
 
@@ -207,7 +207,7 @@ def test_framework_log_output_debug(tmpdir):
     # remove timestamp
     lines = [line[24:] for line in lines]
 
-    assert len(lines) == 22
+    assert len(lines) == 30
     assert "FRAMEWORK       INFO     log message\n" in lines
     assert "FRAMEWORK       DEBUG    debug message\n" in lines
     assert "FRAMEWORK       INFO     info message\n" in lines

--- a/tests/new/test_ips_framework.py
+++ b/tests/new/test_ips_framework.py
@@ -1,6 +1,7 @@
 from ipsframework import Framework
 import glob
 import json
+import pytest
 
 
 def write_basic_config_and_platform_files(tmpdir):
@@ -111,3 +112,106 @@ def test_framework_simple(tmpdir, capfd):
     captured = capfd.readouterr()
     assert captured.out == ''
     assert captured.err == ''
+
+
+def test_framework_empty_config_list(tmpdir):
+
+    with pytest.raises(ValueError) as excinfo:
+        Framework(config_file_list=[],
+                  log_file_name=str(tmpdir.join('test.log')),
+                  platform_file_name='platform.conf',
+                  debug=None,
+                  verbose_debug=None,
+                  cmd_nodes=0,
+                  cmd_ppn=0)
+
+    assert str(excinfo.value).endswith("Missing config file? Something is very wrong")
+
+    # check output log file
+    with open(str(tmpdir.join('test.log')), 'r') as f:
+        lines = f.readlines()
+
+    # remove timestamp
+    lines = [line[24:] for line in lines]
+
+    assert len(lines) == 3
+    assert "FRAMEWORK       ERROR    Missing config file? Something is very wrong\n" in lines
+    assert "FRAMEWORK       ERROR    Problem initializing managers\n" in lines
+    assert "FRAMEWORK       ERROR    exception encountered while cleaning up config_manager\n" in lines
+
+
+def test_framework_log_output(tmpdir):
+    platform_file, config_file = write_basic_config_and_platform_files(tmpdir)
+
+    framework = Framework(config_file_list=[str(config_file)],
+                          log_file_name=str(tmpdir.join('framework_log_test.log')),
+                          platform_file_name=str(platform_file),
+                          debug=None,
+                          verbose_debug=None,
+                          cmd_nodes=0,
+                          cmd_ppn=0)
+
+    framework.log("log message")
+    framework.debug("debug message")
+    framework.info("info message")
+    framework.warning("warning message")
+    framework.error("error message")
+    framework.exception("exception message")
+    framework.critical("critical message")
+
+    framework.terminate_all_sims()
+
+    # check output log file
+    with open(str(tmpdir.join('framework_log_test.log')), 'r') as f:
+        lines = f.readlines()
+
+    # remove timestamp
+    lines = [line[24:] for line in lines]
+
+    assert len(lines) == 9
+    assert "FRAMEWORK       WARNING  warning message\n" in lines
+    assert "FRAMEWORK       ERROR    error message\n" in lines
+    assert "FRAMEWORK       ERROR    exception message\n" in lines
+    assert "FRAMEWORK       CRITICAL critical message\n" in lines
+
+    assert "FRAMEWORK       INFO     log message\n" not in lines
+    assert "FRAMEWORK       DEBUG    debug message\n" not in lines
+    assert "FRAMEWORK       INFO     info message\n" not in lines
+
+
+def test_framework_log_output_debug(tmpdir):
+    platform_file, config_file = write_basic_config_and_platform_files(tmpdir)
+
+    framework = Framework(config_file_list=[str(config_file)],
+                          log_file_name=str(tmpdir.join('framework_log_debug_test.log')),
+                          platform_file_name=str(platform_file),
+                          debug=True,
+                          verbose_debug=False,
+                          cmd_nodes=0,
+                          cmd_ppn=0)
+
+    framework.log("log message")
+    framework.debug("debug message")
+    framework.info("info message")
+    framework.warning("warning message")
+    framework.error("error message")
+    framework.exception("exception message")
+    framework.critical("critical message")
+
+    framework.terminate_all_sims()
+
+    # check output log file
+    with open(str(tmpdir.join('framework_log_debug_test.log')), 'r') as f:
+        lines = f.readlines()
+
+    # remove timestamp
+    lines = [line[24:] for line in lines]
+
+    assert len(lines) == 22
+    assert "FRAMEWORK       INFO     log message\n" in lines
+    assert "FRAMEWORK       DEBUG    debug message\n" in lines
+    assert "FRAMEWORK       INFO     info message\n" in lines
+    assert "FRAMEWORK       WARNING  warning message\n" in lines
+    assert "FRAMEWORK       ERROR    error message\n" in lines
+    assert "FRAMEWORK       ERROR    exception message\n" in lines
+    assert "FRAMEWORK       CRITICAL critical message\n" in lines


### PR DESCRIPTION
Need to test that this doesn't have negative performance implications before merging.

This was originally broken by 98711ca6bf3263f86e5dee68957f2440c038d1f0


Update with Testing performance:

If I have 10 component running simultaneously, all logging to the service every 0.01 seconds, there is no performance difference. This is the most extreme case that you might find in practice.

```python
for i in range(10000):
            time.sleep(0.01)                                                                                                                                                                  
            self.services.info(f"sleep_log {i}")
```

Only in the most extreme cases do I see a difference, so 10 component running simultaneously, all logging to the service as fast as they can

```python
for i in range(10000):
            self.services.info(f"sleep_log {i}")
```
then the total run time goes from ~5 seconds on the current `master` to ~15 seconds on this branch. But the output log file is now correct, `master` log file was 1642 lines long while this branch is 100044 lines. Given that this is unlikely how it will be used I think it is safe to go ahead with this fix.

