### PR TITLE
Update multirun tests

### DIFF
--- a/tests/components/drivers/basic_serial1.py
+++ b/tests/components/drivers/basic_serial1.py
@@ -38,7 +38,7 @@ class basic_serial1(Component):
             raise Exception('Error accessing physics components')
 
         # ssf - get timeloop for simulation
-        timeloop = [1, 2, 3]     # doesn't work yet..... services.getTimeLoop()
+        timeloop = services.get_time_loop()
         tlist_str = ['%.2f' % t for t in timeloop]
 
         # ssf - call init for each component

--- a/tests/components/drivers/basic_serial2.py
+++ b/tests/components/drivers/basic_serial2.py
@@ -38,7 +38,7 @@ class basic_serial2(Component):
             raise Exception('Error accessing physics components')
 
         # ssf - get timeloop for simulation
-        timeloop = [1, 2, 3]     # doesn't work yet..... services.getTimeLoop()
+        timeloop = services.get_time_loop()
         tlist_str = ['%.2f' % t for t in timeloop]
 
         # ssf - call init for each component

--- a/tests/components/workers/large_worker.py
+++ b/tests/components/workers/large_worker.py
@@ -18,7 +18,7 @@ class large_worker(Component):
 
     def step(self, timestamp):
         sleep_time = 1
-        self.services.log('Stepping Worker boogity boogity', self.NPROC, self.BIN_PATH)
+        self.services.log('Stepping Worker timestamp=%s', timestamp)
         cwd = self.services.get_working_dir()
         pid = self.services.launch_task(int(self.NPROC),
                                         cwd,

--- a/tests/components/workers/medium_worker.py
+++ b/tests/components/workers/medium_worker.py
@@ -18,7 +18,7 @@ class medium_worker(Component):
 
     def step(self, timestamp):
         sleep_time = 1
-        self.services.log('Stepping Worker boogity boogity', self.NPROC, self.BIN_PATH)
+        self.services.log('Stepping Worker timestamp=%s', timestamp)
         cwd = self.services.get_working_dir()
         pid = self.services.launch_task(int(self.NPROC),
                                         cwd,

--- a/tests/components/workers/small_worker.py
+++ b/tests/components/workers/small_worker.py
@@ -18,7 +18,7 @@ class small_worker(Component):
 
     def step(self, timestamp):
         sleep_time = 1
-        self.services.log('Stepping Worker boogity boogity', self.NPROC, self.BIN_PATH)
+        self.services.log('Stepping Worker timestamp=%s', timestamp)
         cwd = self.services.get_working_dir()
         pid = self.services.launch_task(int(self.NPROC),
                                         cwd,

--- a/tests/multirun/basic_serial1.ips
+++ b/tests/multirun/basic_serial1.ips
@@ -19,7 +19,7 @@ CURRENT_EQDSK =
 USE_PORTAL=False
 
 LOG_FILE = $SIM_ROOT/$SIM_NAME.log
-LOG_LEVEL = DEBUG                   # Possible values: DEBUG, INFO, WARNING, ERROR, CRITICAL
+LOG_LEVEL = INFO                   # Possible values: DEBUG, INFO, WARNING, ERROR, CRITICAL
 
 [PORTS]
    NAMES = DRIVER WORKER1 WORKER2 WORKER3
@@ -148,7 +148,7 @@ LOG_LEVEL = DEBUG                   # Possible values: DEBUG, INFO, WARNING, ERR
 # For MODE = EXPLICIT, the frame work uses the variable VALUES (space separated list of time values)
 
 [TIME_LOOP]
-   MODE = EXPLICIT
+   MODE = REGULAR
    START = 3.5
    FINISH = 3.7
    NSTEP  = 2

--- a/tests/multirun/basic_serial2.ips
+++ b/tests/multirun/basic_serial2.ips
@@ -19,7 +19,7 @@ CURRENT_EQDSK =
 USE_PORTAL=False
 
 LOG_FILE = $SIM_ROOT/$SIM_NAME.log
-LOG_LEVEL = DEBUG                   # Possible values: DEBUG, INFO, WARNING, ERROR, CRITICAL
+LOG_LEVEL = INFO                   # Possible values: DEBUG, INFO, WARNING, ERROR, CRITICAL
 
 [PORTS]
    NAMES = DRIVER WORKER1 WORKER2 WORKER3
@@ -152,4 +152,4 @@ LOG_LEVEL = DEBUG                   # Possible values: DEBUG, INFO, WARNING, ERR
    START = 3.5
    FINISH = 3.7
    NSTEP  = 2
-   VALUES = 3.4 3.5 3.6 3.7 3.8 3.9
+   VALUES = 3.4 3.5 3.6

--- a/tests/multirun/test_basic_serial.py
+++ b/tests/multirun/test_basic_serial.py
@@ -44,9 +44,9 @@ def test_basic_serial1(tmpdir, capfd):
     assert captured_out[3] == "small_worker : init() called"
     assert captured_out[5] == "medium_worker : init() called"
     assert captured_out[7] == "large_worker : init() called"
-    assert captured_out[9] == "Current time =  1.00"
-    assert captured_out[10] == "Current time =  2.00"
-    assert captured_out[11] == "Current time =  3.00"
+    assert captured_out[9] == "Current time =  3.50"
+    assert captured_out[10] == "Current time =  3.60"
+    assert captured_out[11] == "Current time =  3.70"
 
     # check files copied and created
     driver_files = [os.path.basename(f) for f in glob.glob(str(tmpdir.join("test_basic_serial1_0/work/drivers_testing_basic_serial1_*/*")))]
@@ -57,10 +57,21 @@ def test_basic_serial1(tmpdir, capfd):
     medium_worker_files = [os.path.basename(f) for f in glob.glob(str(tmpdir.join("test_basic_serial1_0/work/workers_testing_medium_worker_*/*")))]
     large_worker_files = [os.path.basename(f) for f in glob.glob(str(tmpdir.join("test_basic_serial1_0/work/workers_testing_large_worker_*/*")))]
 
-    for outfile in ["my_out1.00", "my_out2.00", "my_out3.00"]:
+    for outfile in ["my_out3.50", "my_out3.60", "my_out3.70"]:
         assert outfile in small_worker_files
         assert outfile in medium_worker_files
         assert outfile in large_worker_files
+
+    # check sim log file
+    with open(str(tmpdir.join("test_basic_serial1_0").join("test_basic_serial1_0.log")), 'r') as f:
+        lines = f.readlines()
+
+    # remove timestamp
+    lines = [line[24:] for line in lines]
+
+    for worker in ["small_worker_2", "medium_worker_3", "large_worker_4"]:
+        for timestamp in ["3.50", "3.60", "3.70"]:
+            assert f'workers_testing_{worker} INFO     Stepping Worker timestamp={timestamp}\n' in lines
 
 
 def test_basic_serial_multi(tmpdir, capfd):
@@ -124,7 +135,29 @@ def test_basic_serial_multi(tmpdir, capfd):
         medium_worker_files = [os.path.basename(f) for f in glob.glob(str(tmpdir.join(f"test_basic_serial{no}_0/work/workers_testing_medium_worker_*/*")))]
         large_worker_files = [os.path.basename(f) for f in glob.glob(str(tmpdir.join(f"test_basic_serial{no}_0/work/workers_testing_large_worker_*/*")))]
 
-        for outfile in ["my_out1.00", "my_out2.00", "my_out3.00"]:
+        for outfile in ["my_out3.50", "my_out3.60", "my_out3.70"]:
             assert outfile in small_worker_files
             assert outfile in medium_worker_files
             assert outfile in large_worker_files
+
+    # check basic_serial1 sim log file
+    with open(str(tmpdir.join("test_basic_serial1_0").join("test_basic_serial1_0.log")), 'r') as f:
+        lines = f.readlines()
+
+    # remove timestamp
+    lines = [line[24:] for line in lines]
+
+    for worker in ["small_worker_2", "medium_worker_3", "large_worker_4"]:
+        for timestamp in ["3.50", "3.60", "3.70"]:
+            assert f'workers_testing_{worker} INFO     Stepping Worker timestamp={timestamp}\n' in lines
+
+    # check basic_serial2 sim log file
+    with open(str(tmpdir.join("test_basic_serial2_0").join("test_basic_serial2_0.log")), 'r') as f:
+        lines = f.readlines()
+
+    # remove timestamp
+    lines = [line[24:] for line in lines]
+
+    for worker in ["small_worker_6", "medium_worker_7", "large_worker_8"]:
+        for timestamp in ["3.40", "3.50", "3.60"]:
+            assert f'workers_testing_{worker} INFO     Stepping Worker timestamp={timestamp}\n' in lines


### PR DESCRIPTION
This fixes the get_time_loop of the drivers and the service.log calls of the workers