### PR TITLE
Add macOS to github actions CI, only python 3.6 and 3.7 for now

### DIFF
--- a/.github/workflows/workflows_macos.yml
+++ b/.github/workflows/workflows_macos.yml
@@ -1,0 +1,31 @@
+name: macOS CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install python testing dependencies
+      run: pip install pytest-runner pytest-cov psutil numpy dask distributed
+    - name: Install IPS (in develop mode)
+      run: python setup.py develop
+    - name: testing running IPS (--help)
+      run: ips.py --help
+    - name: testing showing IPS version (--version)
+      run: ips.py --version
+    - name: Test with pytest
+      run: python setup.py test --addopts --cov
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1

--- a/tests/multirun/test_basic_serial.py
+++ b/tests/multirun/test_basic_serial.py
@@ -2,6 +2,7 @@ from ipsframework import Framework
 import os
 import shutil
 import glob
+import pytest
 
 
 def copy_config_and_replace(infile, srcdir, tmpdir):
@@ -16,6 +17,7 @@ def copy_config_and_replace(infile, srcdir, tmpdir):
                     fout.write(line)
 
 
+@pytest.mark.skipif(not shutil.which('mpirun'), reason="missing mpirun")
 def test_basic_serial1(tmpdir, capfd):
     datadir = os.path.dirname(__file__)
     copy_config_and_replace("basic_serial1.ips", datadir, tmpdir)
@@ -74,6 +76,7 @@ def test_basic_serial1(tmpdir, capfd):
             assert f'workers_testing_{worker} INFO     Stepping Worker timestamp={timestamp}\n' in lines
 
 
+@pytest.mark.skipif(not shutil.which('mpirun'), reason="missing mpirun")
 def test_basic_serial_multi(tmpdir, capfd):
     # This is the same as test_basic_serial1 except that 2 simulation files are use at the same time
     datadir = os.path.dirname(__file__)
@@ -163,6 +166,7 @@ def test_basic_serial_multi(tmpdir, capfd):
             assert f'workers_testing_{worker} INFO     Stepping Worker timestamp={timestamp}\n' in lines
 
 
+@pytest.mark.skipif(not shutil.which('mpirun'), reason="missing mpirun")
 def test_basic_concurrent1(tmpdir, capfd):
     datadir = os.path.dirname(__file__)
     copy_config_and_replace("basic_concurrent1.ips", datadir, tmpdir)


### PR DESCRIPTION
Ref #105

IPS currently fails with python 3.8 and 3.9 because of (from https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods)
 > Changed in version 3.8: On macOS, the spawn start method is now the default. The fork start method should be considered unsafe as it can lead to crashes of the subprocess. See [bpo-33725](https://bugs.python.org/issue33725).