### PR TITLE
Add python 3.8 and 3.9 to macOS CI forcing fork method with multiprocessing

### DIFF
--- a/.github/workflows/workflows_macos.yml
+++ b/.github/workflows/workflows_macos.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/ipsframework/configurationManager.py
+++ b/ipsframework/configurationManager.py
@@ -7,11 +7,20 @@ import importlib
 import tempfile
 import logging
 import socket
-from multiprocessing import Queue, Process
+from multiprocessing import Queue, Process, set_start_method
 from .configobj import ConfigObj
 from . import ipsLogging
 from .services import ServicesProxy
 from .componentRegistry import ComponentID, ComponentRegistry
+
+# Try using fork for starting subprocesses, this is the default on
+# Linux but not macOS with python >= 3.8
+if sys.platform == 'darwin':
+    try:
+        set_start_method('fork')
+    except RuntimeError:
+        # context can only be set once
+        pass
 
 
 class ConfigurationManager:

--- a/tests/helloworld/test_helloworld.py
+++ b/tests/helloworld/test_helloworld.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import json
 import glob
+import pytest
 
 
 def copy_config_and_replace(infile, outfile, tmpdir, task_pool=False, portal=False, dask=False):
@@ -147,6 +148,8 @@ def test_helloworld_task_pool(tmpdir, capfd):
 
 
 def test_helloworld_task_pool_dask(tmpdir, capfd):
+    pytest.importorskip("dask")
+    pytest.importorskip("distributed")
     from ipsframework import TaskPool
     assert TaskPool.dask is not None
 


### PR DESCRIPTION
Closes #105