### PR TITLE
Fix dask import

### DIFF
--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -1951,10 +1951,9 @@ class TaskPool:
         distributed: dask.distributed = __import__("dask.distributed",
                                                    fromlist=[None])
     except ImportError:
-        pass
+        dask = None
+        distributed = None
     else:
-        dask_scheduler = None
-        dask_worker = None
         dask_scheduler = shutil.which("dask-scheduler")
         dask_worker = shutil.which("dask-worker")
         if not dask_scheduler or not dask_worker:


### PR DESCRIPTION
If `import dask` successed but `import dask.distributed` failed then dask wasn't set back to None and IPS will fail when trying to access dask_scheduler and dask_worker