### PR TITLE
Add Dakota test to CI

### DIFF
--- a/.github/workflows/conda_env/environment_dask_2.30.0.yml
+++ b/.github/workflows/conda_env/environment_dask_2.30.0.yml
@@ -1,0 +1,10 @@
+name: test
+channels:
+- conda-forge
+dependencies:
+- pytest-cov
+- pytest-timeout
+- psutil
+- mpi4py
+- dask=2.30.0
+- dakota

--- a/.github/workflows/conda_env/environment_dask_2.5.2.yml
+++ b/.github/workflows/conda_env/environment_dask_2.5.2.yml
@@ -1,0 +1,10 @@
+name: test
+channels:
+- conda-forge
+dependencies:
+- pytest-cov
+- pytest-timeout
+- psutil
+- mpi4py
+- dask=2.5.2
+- dakota

--- a/.github/workflows/conda_env/environment_linux.yml
+++ b/.github/workflows/conda_env/environment_linux.yml
@@ -1,0 +1,10 @@
+name: test
+channels:
+- conda-forge
+dependencies:
+- pytest-cov
+- pytest-timeout
+- psutil
+- mpi4py
+- dask=2021.09.0
+- dakota

--- a/.github/workflows/conda_env/environment_macos.yml
+++ b/.github/workflows/conda_env/environment_macos.yml
@@ -1,0 +1,8 @@
+name: test
+channels:
+- conda-forge
+dependencies:
+- pytest-cov
+- pytest-timeout
+- psutil
+- dask=2021.09.0

--- a/.github/workflows/conda_env/environment_py36.yml
+++ b/.github/workflows/conda_env/environment_py36.yml
@@ -1,0 +1,7 @@
+name: test
+channels:
+- conda-forge
+dependencies:
+- pytest-cov
+- pytest-timeout
+- psutil

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -32,41 +32,47 @@ jobs:
 
     timeout-minutes: 10
 
+    defaults:
+      run:
+        shell: bash -l {0}
+
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        dask-version: ['2021.08.0']
+        os: [ubuntu-latest]
+        python-version: [3.7, 3.8, 3.9]
+        conda_env: ['linux']
         include:
+          - os: ubuntu-latest
+            python-version: 3.6
+            conda_env: 'py36'
           # same as NERSC Cori module python/3.7-anaconda-2019.10
           - os: ubuntu-latest
             python-version: 3.7
-            dask-version: '2.5.2'
+            conda_env: 'dask_2.5.2'
           # same as NERSC Cori module python/3.8-anaconda-2020.11
           - os: ubuntu-latest
             python-version: 3.8
-            dask-version: '2.30.0'
+            conda_env: 'dask_2.30.0'
+          - os: macos-latest
+            python-version: 3.6
+            conda_env: 'py36'
+          - os: macos-latest
+            python-version: 3.7
+            conda_env: 'macos'
+          - os: macos-latest
+            python-version: 3.8
+            conda_env: 'macos'
+          - os: macos-latest
+            python-version: 3.9
+            conda_env: 'macos'
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - uses: conda-incubator/setup-miniconda@v2
       with:
+        auto-update-conda: true
         python-version: ${{ matrix.python-version }}
-    - name: Install python testing dependencies
-      run: python -m pip install pytest-cov pytest-timeout psutil
-    # There is an issue with click 8 for dask < 2021.05 dask/dask#7658
-    - name: Install dask ${{ matrix.dask-version }} with click<8
-      if: ${{ matrix.python-version > 3.6 && matrix.dask-version < '2021.05.0' }}
-      run: python -m pip install dask==${{ matrix.dask-version }} distributed==${{ matrix.dask-version }} "click<8" msgpack==0.6.2
-    - name: Install dask ${{ matrix.dask-version }}
-      if: ${{ matrix.python-version > 3.6 && matrix.dask-version >= '2021.05.0' }}
-      run: python -m pip install dask==${{ matrix.dask-version }} distributed==${{ matrix.dask-version }}
-    - name: Install mpi testing dependencies
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libopenmpi-dev python3-mpi4py
+        environment-file: .github/workflows/conda_env/environment_${{ matrix.conda_env }}.yml
     - name: Install IPS (in develop mode)
       run: python -m pip install -e .
     - name: testing running IPS (--help)
@@ -74,7 +80,7 @@ jobs:
     - name: testing showing IPS version (--version)
       run: ips.py --version
     - name: Test with pytest
-      run: python -m pytest --cov --verbose --timeout=60
+      run: python -m pytest --cov --cov-report=xml --cov-report=term --verbose --timeout=60
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
 
@@ -94,10 +100,11 @@ jobs:
       with:
           distribution: Ubuntu-20.04
           additional-packages:
-              python3-pip
               python-is-python3
-    - name: Install python testing dependencies
-      run: python -m pip install pytest-cov pytest-timeout psutil dask==2021.08.0 distributed==2021.08.0
+              python3-pip
+              python3-pytest-cov
+              python3-pytest-timeout
+              python3-psutil
     - name: Install IPS (in develop mode)
       run: python -m pip install -e .
     - name: testing running IPS (--help)

--- a/ipsframework/dakota_bridge.py
+++ b/ipsframework/dakota_bridge.py
@@ -31,7 +31,7 @@ class Driver(Component):
     def init(self, timestamp=0, **keywords):
         self.services.subscribe('_IPS_DYNAMIC_SIMULATION', "process_event")
 
-    def step(self, timestamp=0, **keywords):
+    def step(self, timestamp=0, **keywords):  # pragma: no cover
 
         services = self.services
         sim_root = services.get_config_param('SIM_ROOT')

--- a/tests/dakota/dakota_test_Gaussian.in
+++ b/tests/dakota/dakota_test_Gaussian.in
@@ -1,4 +1,4 @@
-# DAKOTA INPUT FILE - dakota_rosenbrock_syscall.in
+# DAKOTA INPUT FILE - dakota_gaussian_syscall.in
 
 strategy
   single_method
@@ -15,11 +15,11 @@ model
   single
 
 variables
-  continuous_design = 2
-  initial_point  -1.2  1.0
-  lower_bounds   -2.0     -2.0
-  upper_bounds    2.0      2.0
-  descriptors      'ROSE__X1'     "ROSE__X2"
+  continuous_design = 1
+  initial_point   0.0
+  lower_bounds    -1.0
+  upper_bounds    1.0
+  descriptors      'GAUSS__X'
 
 interface
   fork asynchronous evaluation_concurrency = 10, file_tag, file_save

--- a/tests/dakota/dakota_test_Gaussian.ips
+++ b/tests/dakota/dakota_test_Gaussian.ips
@@ -1,0 +1,68 @@
+RUN_ID = DAKOTA_Rosenbrock                   # Identifier for this simulation run
+TOKAMAK_ID = TEST
+SHOT_NUMBER = 1                  # Numerical identifier for specific case
+
+SIM_NAME = ${RUN_ID}_${TOKAMAK_ID}_${SHOT_NUMBER}  # Name of current simulation
+SIM_ROOT = $PWD/${SIM_NAME}                   # Where to put results from this simulation
+
+LOG_FILE = $SIM_ROOT/${RUN_ID}.log
+LOG_LEVEL = DEBUG
+
+SIMULATION_MODE = NORMAL
+
+# A run comment picked up by the portal
+RUN_COMMENT = Testing dakota
+
+# Specification of plasma state files
+
+# Where to put plasma state files as the simulation evolves 
+PLASMA_STATE_WORK_DIR = $SIM_ROOT/work/plasma_state
+
+# Specify what files constitute the plasma state - N.B. not all components need all files
+PLASMA_STATE_FILES = 
+
+# Names of ports to be used.  An implementation and configuration must be specified for
+# each port
+
+[PORTS]
+   NAMES = DRIVER 
+   
+# DRIVER port is called by the framework.  It is required, causes exception.
+
+   [[DRIVER]]                                       # REQUIRED Port section 
+      IMPLEMENTATION = GAUSS
+                                                    
+# INIT port is called by the framework.  It typically produces the very first set of
+# plasma state files for SIMULATION_MODE = NORMAL.  It does not raise and exception
+# if missing.
+                                                    
+   [[INIT]]   
+      IMPLEMENTATION =  
+
+# Specification of IMPLEMENTATION for each physics port called out in PORTS list.
+# Additional specifications may be present that are not in the PORTS list
+
+# Specification of configuration for each port called out in PORTS list.
+# Additional specifications may be present that are not in the PORTS list
+# NAME variable MUST match the name of the python class that implements the component
+
+[GAUSS]
+    CLASS = DAKOTA
+    SUB_CLASS = TEST
+    NAME = GaussianWellDriver
+    NPROC = 1
+    BIN_PATH =
+    INPUT_DIR =
+    INPUT_FILES = 
+    OUTPUT_FILES =  
+    SCRIPT = $PWD/dakota_test_Gaussian.py
+
+# Time loop specification (two modes for now) EXPLICIT | REGULAR
+# For MODE = REGULAR, the framework uses the variables START, FINISH, and NSTEP
+# For MODE = EXPLICIT, the frame work uses the variable VALUES (space separated list of time values)
+
+[TIME_LOOP]
+   MODE = REGULAR
+   START = 0 
+   FINISH = 10 
+   NSTEP  = 10

--- a/tests/dakota/dakota_test_Gaussian.py
+++ b/tests/dakota/dakota_test_Gaussian.py
@@ -1,0 +1,17 @@
+# -------------------------------------------------------------------------------
+# Copyright 2006-2021 UT-Battelle, LLC. See LICENSE for more information.
+# -------------------------------------------------------------------------------
+import os
+from math import exp
+from ipsframework import Component
+
+
+class GaussianWellDriver(Component):
+    def step(self, timestamp=0):
+        print('step from dakota test driver')
+        self.services.stage_input_files(self.INPUT_FILES)
+        x = float(self.X)
+        sim_root = self.services.get_config_param('SIM_ROOT')
+        result = -exp(-(x-0.5)**2)
+        out_file = os.path.join(sim_root, 'RESULT')
+        open(out_file, 'w').write('%.9f f' % (result))

--- a/tests/dakota/dakota_test_Rosenbrock.py
+++ b/tests/dakota/dakota_test_Rosenbrock.py
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------------------
-# Copyright 2006-2012 UT-Battelle, LLC. See LICENSE for more information.
+# Copyright 2006-2021 UT-Battelle, LLC. See LICENSE for more information.
 # -------------------------------------------------------------------------------
 import os
 from ipsframework import Component


### PR DESCRIPTION
Created an easier/faster test for ips_dakota_dynamic. Change the CI to use conda, this allows easy install of Dakota.