### PR TITLE
192 improve ensemble error checking

### DIFF
--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2153,22 +2153,38 @@ class ServicesProxy:
                     if variable not in template[component[0]]:
                         # If we are passed in a variable to be substituted
                         # that isn't in the template, complain and move one.
-                        self.critical(f'Variable {variable} not found in template ... skipping')
-                        raise RuntimeError(f'Variable {variable} not found in template')
+                        self.critical(f'Variable {variable} not found in '
+                                      f'template ... skipping')
+                        raise RuntimeError(f'Variable {variable} not found '
+                                           f'in template')
                     else:
                         if template[component[0]][variable] is None \
                                 or template[component[0]][variable] == '':
+                            # User probably forgot to put in a '?', so just
+                            # complain and keep moving.
                             self.warning(f'Variable {variable} is empty and '
                                          f'does not have a "?" indicating '
                                          f'it is a variable')
+                            self.debug(f'Substituting {component[1][variable]} '
+                                       f'for {variable}')
+                            template[component[0]][variable] = \
+                                component[1][variable]
                         elif template[component[0]][variable] == '?':
-                            self.debug(f'Substituting {component[1][variable]} for {variable}')
-                            template[component[0]][variable] = component[1][variable]
+                            # This is the proper scenario where the user has
+                            # explicitly identified a variable with '?' in the
+                            # template config file to be substituted for one
+                            # of the given variables.
+                            self.debug(f'Substituting {component[1][variable]} '
+                                       f'for {variable}')
+                            template[component[0]][variable] = \
+                                component[1][variable]
                         else:
                             # It already has a value, so complain and exit.
-                            self.critical(f'Variable {variable} already has a value '
+                            self.critical(f'Variable {variable} already has '
+                                          f'a value '
                                           f'of {template[component[0]][variable]}')
-                            raise RuntimeError(f'Variable {variable} already has a value')
+                            raise RuntimeError(f'Variable {variable} already '
+                                               f'has a value')
 
             template['LOG_FILE'] = working_dir / Path(prefix + "_run.log")
             template.filename = working_dir / Path(prefix + ".config")

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2147,6 +2147,7 @@ class ServicesProxy:
 
             for component in variables:
                 self.debug(f'Substituting for {component[0]}')
+
                 for variable in component[1].keys():
                     # Substitute the individual variables for this component
                     self.debug(f'Assigning {component[1][variable]} to {variable}')
@@ -2185,6 +2186,17 @@ class ServicesProxy:
                                           f'of {template[component[0]][variable]}')
                             raise RuntimeError(f'Variable {variable} already '
                                                f'has a value')
+
+            # Now scan for any remaining '?' variables that haven't been
+            # assigned.
+            for section in template.keys():
+                if isinstance(template[section], dict):
+                    for variable in template[section].keys():
+                        if template[section][variable] == '?':
+                            self.critical(f'Variable {variable} in section {section} '
+                                          f'has not been assigned')
+                            raise RuntimeError(f'Variable {variable} in section '
+                                               f'{section} has not been assigned')
 
             template['LOG_FILE'] = working_dir / Path(prefix + "_run.log")
             template.filename = working_dir / Path(prefix + ".config")

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2150,7 +2150,13 @@ class ServicesProxy:
                 for variable in component[1].keys():
                     # Substitute the individual variables for this component
                     self.debug(f'Assigning {component[1][variable]} to {variable}')
-                    template[component[0]][variable] = component[1][variable]
+                    if variable not in template[component[0]]:
+                        # If we are passed in a variable to be substituted
+                        # that isn't in the template, complain and move one.
+                        self.critical(f'Variable {variable} not found in template ... skipping')
+                        raise RuntimeError(f'Variable {variable} not found in template')
+                    else:
+                        template[component[0]][variable] = component[1][variable]
 
             template['LOG_FILE'] = working_dir / Path(prefix + "_run.log")
             template.filename = working_dir / Path(prefix + ".config")

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2175,6 +2175,9 @@ class ServicesProxy:
                             # explicitly identified a variable with '?' in the
                             # template config file to be substituted for one
                             # of the given variables.
+                            # TODO that the next two statements show up in
+                            # the previous block means we can probably refactor
+                            # this if block to be more concise.
                             self.debug(f'Substituting {component[1][variable]} '
                                        f'for {variable}')
                             template[component[0]][variable] = \

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2161,7 +2161,14 @@ class ServicesProxy:
                             self.warning(f'Variable {variable} is empty and '
                                          f'does not have a "?" indicating '
                                          f'it is a variable')
-                        template[component[0]][variable] = component[1][variable]
+                        elif template[component[0]][variable] == '?':
+                            self.debug(f'Substituting {component[1][variable]} for {variable}')
+                            template[component[0]][variable] = component[1][variable]
+                        else:
+                            # It already has a value, so complain and exit.
+                            self.critical(f'Variable {variable} already has a value '
+                                          f'of {template[component[0]][variable]}')
+                            raise RuntimeError(f'Variable {variable} already has a value')
 
             template['LOG_FILE'] = working_dir / Path(prefix + "_run.log")
             template.filename = working_dir / Path(prefix + ".config")

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2156,6 +2156,11 @@ class ServicesProxy:
                         self.critical(f'Variable {variable} not found in template ... skipping')
                         raise RuntimeError(f'Variable {variable} not found in template')
                     else:
+                        if template[component[0]][variable] is None \
+                                or template[component[0]][variable] == '':
+                            self.warning(f'Variable {variable} is empty and '
+                                         f'does not have a "?" indicating '
+                                         f'it is a variable')
                         template[component[0]][variable] = component[1][variable]
 
             template['LOG_FILE'] = working_dir / Path(prefix + "_run.log")

--- a/tests/ensembles/README.md
+++ b/tests/ensembles/README.md
@@ -1,0 +1,3 @@
+This contains the tests for enemble methods.
+
+* `basic` - tests for basic, simple ensemble setup that should run normally

--- a/tests/ensembles/README.md
+++ b/tests/ensembles/README.md
@@ -4,3 +4,5 @@ This contains the tests for enemble methods.
 * `already-exists` - tests for variables already assigned in template
 * `missing-assignment` - tests for missing variable declarations in template 
   configuration files
+* `extra-variable` - tests for extra variable declarations in template 
+  configuration files

--- a/tests/ensembles/README.md
+++ b/tests/ensembles/README.md
@@ -1,6 +1,6 @@
 This contains the tests for enemble methods.
 
 * `basic` - tests for basic, simple ensemble setup that should run normally
-* `bad-assignment` - tests for missing '?' or empty variable assignments
+* `already-exists` - tests for variables already assigned in template
 * `missing-assignment` - tests for missing variable declarations in template 
   configuration files

--- a/tests/ensembles/README.md
+++ b/tests/ensembles/README.md
@@ -1,3 +1,6 @@
 This contains the tests for enemble methods.
 
 * `basic` - tests for basic, simple ensemble setup that should run normally
+* `bad-assignment` - tests for missing '?' or empty variable assignments
+* `missing-assignment` - tests for missing variable declarations in template 
+  configuration files

--- a/tests/ensembles/already-exists/a_sim_comp.py
+++ b/tests/ensembles/already-exists/a_sim_comp.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+""" Component wrapper for the ensemble example for `a_sim`. """
+from ipsframework import Component
+
+
+class a_sim_comp(Component):
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Created %s' % (self.__class__))
+
+    def step(self, timestamp=0.0):
+        # TODO echo parameters for this run
+        print('Hello from a_sim_comp')
+
+        # Echo the parameters we're expecting, A, B, and C
+        print(f'a_sim_comp parameters: A={self.A}, B={self.B}, C={self.C}')

--- a/tests/ensembles/already-exists/another_sim_comp.py
+++ b/tests/ensembles/already-exists/another_sim_comp.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+""" Component wrapper for the ensemble example for `another_sim`. """
+from ipsframework import Component
+
+
+class another_sim_comp(Component):
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Created %s' % (self.__class__))
+
+    def step(self, timestamp=0.0):
+        # TODO echo parameters for this run
+        print('Hello from another_sim_comp')
+
+        # Echo the parameters we're expecting, D, B, and F
+        print(f'another_sim_comp parameters: D={self.D}, B={self.B}, F={self.F}')

--- a/tests/ensembles/already-exists/driver.config
+++ b/tests/ensembles/already-exists/driver.config
@@ -1,0 +1,31 @@
+# Example configuration file for ensemble support
+
+SIM_ROOT = $PWD
+SIM_NAME = ensemble_example
+ENSEMBLE_DIR = /tmp/ensembles
+ENSEMBLE_PREFIX = MY_INSTANCE_
+LOG_FILE = run.log
+LOG_LEVEL = INFO
+SIMULATION_MODE = NORMAL
+
+[PORTS]
+    NAMES = DRIVER
+
+    [[DRIVER]]
+        IMPLEMENTATION = driver
+
+[driver]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/tests/ensembles/already-exists/
+    CLASS = driver
+    SUB_CLASS =
+    NAME = ensemble_driver
+    SCRIPT = ${BIN_PATH}/driver.py
+    TEMPLATE = ${BIN_PATH}/template.config
+    PLATFORM_CONFIG_FILE = ${BIN_PATH}/mac135909.config
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+
+

--- a/tests/ensembles/already-exists/driver.py
+++ b/tests/ensembles/already-exists/driver.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+    Example driver for the ensembles example.
+
+    Please note that run_ensemble can be run from any IPS component, not
+    just a driver. The driver is used here for simplicity.
+"""
+from pathlib import Path
+
+from ipsframework import Component
+
+
+class ensemble_driver(Component):
+
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Creating driver')
+
+    def init(self, timeStamp=0.0):
+        return
+
+    def step(self, timestamp=0.0, **keywords):
+        """ set up and run the ensemble
+        """
+        # ENSEMBLE_DIR is an arbitrary variable denoting where we want to run
+        # all the ensembles.  You don't have to use ENSEMBLE_DIR. You can
+        # even hardcode the path here.  Whatever.
+        run_dir = Path(self.services.get_config_param('ENSEMBLE_DIR'))
+        self.services.info(f'Running ensemble in {run_dir}')
+
+        # ENSEMBLE_PREFIX is an optional config variable for specifying
+        # a string to prepend to the ensemble run directories and generated
+        # files.  If not specified, the default is 'INSTANCE_n' where n is
+        # is the arbitrary instance ID.
+        prefix = self.services.get_config_param('ENSEMBLE_PREFIX',
+                                                silent=True)
+        if not prefix or prefix == '' or prefix == {}:
+            self.services.info('No ensemble instance prefix specified. Using '
+                               'default of INSTANCE_.')
+            prefix = "INSTANCE_"
+        else:
+            self.services.info(f'Using ensemble instance prefix {prefix}')
+
+        if not run_dir.exists():
+            self.services.info(f'Creating {run_dir}')
+            run_dir.mkdir(parents=True)
+
+        template = Path(self.config['TEMPLATE'])
+        self.services.info(f'Using template config file {template}')
+
+        if not template.exists():
+            raise RuntimeError(f'{template} config template file does not exist')
+
+        # PLATFORM_CONFIG_FILE is a variable that points to the platform
+        # config file used by the ensembles.  This could be the same
+        # platform config file used for this driver, but it doesn't have to be.
+        platform_config = self.config['PLATFORM_CONFIG_FILE']
+        self.services.info(f'Using platform config file {platform_config}')
+
+        # Specifies different sets of variable values for concurrent ensemble
+        # runs for two different components, 'a_sim_comp' and
+        # 'another_sim_comp', that correspond to two different coupled
+        # simulations.  We chose two components to demonstrate that the same
+        # variable, in this case 'B', can have different values for different
+        # components. 'a_sim_comp' and 'another_sim_comp' are the names of
+        # the config sections in the template file so we know where to look
+        # for variable substitutions.
+        variables = {'a_sim_comp': {'A': [3, 2, 4],
+                                    'B': [2.34, 5.82, 0.1],
+                                    'C': ['bar', 'baz', 'quux']},
+                     'another_sim_comp': {'D': [7, 5, 9],
+                                          'B': [0.775, 0.080, 29.2],
+                                          'F': ['xyzzy', 'plud', 'thud']}}
+
+        # Spins up N tasks, in this case three, each with a different set of
+        # variable values. `mapping` is a data struct that associates the
+        # specific simulation to a given run directory so that the user can
+        # easily find output for a specific run.
+        mapping = self.services.run_ensemble(template,
+                                             variables,
+                                             run_dir,
+                                             platform_config,
+                                             prefix)
+
+        self.services.info(f'Mapping of dirs to parameters: {mapping!s}')
+
+
+    def finalize(self, timeStamp=0.0):
+        return
+

--- a/tests/ensembles/already-exists/instance_driver.py
+++ b/tests/ensembles/already-exists/instance_driver.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+    Example driver for the ensembles example.
+
+    Please note that run_ensemble can be run from any IPS component, not
+    just a driver. The driver is used here for simplicity.
+"""
+from pathlib import Path
+
+from ipsframework import Component
+
+
+class instance_driver(Component):
+
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Creating instance driver')
+
+    def init(self, timeStamp=0.0):
+        return
+
+    def step(self, timestamp=0.0, **keywords):
+        """ Run the ensemble instance workers
+
+            In this example we have two components for an
+            example coupled simulation.  The components are
+            'a_sim_comp' and 'another_sim_comp'.  Here, we step
+            each of those components where they echo their
+            unique parameters.
+        """
+        self.services.info('Getting component ports')
+        a_sim_comp = self.services.get_port('A_SIM_COMP')
+        another_sim_comp = self.services.get_port('ANOTHER_SIM_COMP')
+
+        self.services.info('Stepping components')
+        self.services.call(a_sim_comp, 'step', 0.0)
+        self.services.call(another_sim_comp, 'step', 0.0)
+
+        self.services.info('Finished stepping components')
+

--- a/tests/ensembles/already-exists/mac135909.config
+++ b/tests/ensembles/already-exists/mac135909.config
@@ -1,0 +1,19 @@
+# Where the source is for my laptop
+SRC_DIR = /Users/may/Projects/IPS
+
+#######################################
+# Parallel environment
+#######################################
+MPIRUN = eval
+NODE_DETECTION = manual
+CORES_PER_NODE = 12
+SOCKETS_PER_NODE = 2
+NODE_ALLOCATION_MODE =  shared
+
+#######################################
+# Provenance
+#######################################
+HOST = localhost
+USER = may
+HOME = $HOME
+SCRATCH = /tmp

--- a/tests/ensembles/already-exists/template.config
+++ b/tests/ensembles/already-exists/template.config
@@ -1,0 +1,61 @@
+# Template config file that will be used to generate the ensemble runs. Variables
+# will be substituted from run_ensemble() in the driver script.
+SIM_ROOT = $PWD
+SIM_NAME = ensemble_missing_assignment
+LOG_FILE = run.log
+LOG_LEVEL = INFO
+SIMULATION_MODE = NORMAL
+
+[PORTS]
+    NAMES = DRIVER A_SIM_COMP ANOTHER_SIM_COMP
+
+    [[DRIVER]]
+        IMPLEMENTATION = driver
+
+    [[A_SIM_COMP]]
+        IMPLEMENTATION = a_sim_comp
+
+    [[ANOTHER_SIM_COMP]]
+        IMPLEMENTATION = another_sim_comp
+
+[driver]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/tests/ensembles/already-exists/
+    CLASS = driver
+    SUB_CLASS =
+    NAME = instance_driver
+    SCRIPT = ${BIN_PATH}/instance_driver.py
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+
+[a_sim_comp]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/tests/ensembles/already-exists/
+    CLASS = workers
+    SUB_CLASS =
+    NAME = a_sim_comp
+    SCRIPT = ${BIN_PATH}/a_sim_comp.py
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+    A = 4.2 # This should be ? and not a constant, so it's a mistake we should catch
+    B = ?
+    C = ?
+
+[another_sim_comp]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/tests/ensembles/already-exists/
+    CLASS = workers
+    SUB_CLASS =
+    NAME = another_sim_comp
+    SCRIPT = ${BIN_PATH}/another_sim_comp.py
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+    D = ?
+    B = ?
+    F = ?

--- a/tests/ensembles/basic/a_sim_comp.py
+++ b/tests/ensembles/basic/a_sim_comp.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+""" Component wrapper for the ensemble example for `a_sim`. """
+from ipsframework import Component
+
+
+class a_sim_comp(Component):
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Created %s' % (self.__class__))
+
+    def step(self, timestamp=0.0):
+        # TODO echo parameters for this run
+        print('Hello from a_sim_comp')
+
+        # Echo the parameters we're expecting, A, B, and C
+        print(f'a_sim_comp parameters: A={self.A}, B={self.B}, C={self.C}')

--- a/tests/ensembles/basic/another_sim_comp.py
+++ b/tests/ensembles/basic/another_sim_comp.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+""" Component wrapper for the ensemble example for `another_sim`. """
+from ipsframework import Component
+
+
+class another_sim_comp(Component):
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Created %s' % (self.__class__))
+
+    def step(self, timestamp=0.0):
+        # TODO echo parameters for this run
+        print('Hello from another_sim_comp')
+
+        # Echo the parameters we're expecting, D, B, and F
+        print(f'another_sim_comp parameters: D={self.D}, B={self.B}, F={self.F}')

--- a/tests/ensembles/basic/driver.config
+++ b/tests/ensembles/basic/driver.config
@@ -16,7 +16,7 @@ SIMULATION_MODE = NORMAL
 
 [driver]
     # SRC_DIR specified in platform config
-    BIN_PATH = $SRC_DIR/IPS-framework/doc/examples/ensembles/
+    BIN_PATH = $SRC_DIR/IPS-framework/tests/ensembles/basic/
     CLASS = driver
     SUB_CLASS =
     NAME = ensemble_driver

--- a/tests/ensembles/basic/driver.config
+++ b/tests/ensembles/basic/driver.config
@@ -1,0 +1,31 @@
+# Example configuration file for ensemble support
+
+SIM_ROOT = $PWD
+SIM_NAME = ensemble_example
+ENSEMBLE_DIR = /tmp/ensembles
+ENSEMBLE_PREFIX = MY_INSTANCE_
+LOG_FILE = run.log
+LOG_LEVEL = INFO
+SIMULATION_MODE = NORMAL
+
+[PORTS]
+    NAMES = DRIVER
+
+    [[DRIVER]]
+        IMPLEMENTATION = driver
+
+[driver]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/doc/examples/ensembles/
+    CLASS = driver
+    SUB_CLASS =
+    NAME = ensemble_driver
+    SCRIPT = ${BIN_PATH}/driver.py
+    TEMPLATE = ${BIN_PATH}/template.config
+    PLATFORM_CONFIG_FILE = ${BIN_PATH}/mac135909.config
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+
+

--- a/tests/ensembles/basic/driver.py
+++ b/tests/ensembles/basic/driver.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+    Example driver for the ensembles example.
+
+    Please note that run_ensemble can be run from any IPS component, not
+    just a driver. The driver is used here for simplicity.
+"""
+from pathlib import Path
+
+from ipsframework import Component
+
+
+class ensemble_driver(Component):
+
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Creating driver')
+
+    def init(self, timeStamp=0.0):
+        return
+
+    def step(self, timestamp=0.0, **keywords):
+        """ set up and run the ensemble
+        """
+        # ENSEMBLE_DIR is an arbitrary variable denoting where we want to run
+        # all the ensembles.  You don't have to use ENSEMBLE_DIR. You can
+        # even hardcode the path here.  Whatever.
+        run_dir = Path(self.services.get_config_param('ENSEMBLE_DIR'))
+        self.services.info(f'Running ensemble in {run_dir}')
+
+        # ENSEMBLE_PREFIX is an optional config variable for specifying
+        # a string to prepend to the ensemble run directories and generated
+        # files.  If not specified, the default is 'INSTANCE_n' where n is
+        # is the arbitrary instance ID.
+        prefix = self.services.get_config_param('ENSEMBLE_PREFIX',
+                                                silent=True)
+        if not prefix or prefix == '' or prefix == {}:
+            self.services.info('No ensemble instance prefix specified. Using '
+                               'default of INSTANCE_.')
+            prefix = "INSTANCE_"
+        else:
+            self.services.info(f'Using ensemble instance prefix {prefix}')
+
+        if not run_dir.exists():
+            self.services.info(f'Creating {run_dir}')
+            run_dir.mkdir(parents=True)
+
+        template = Path(self.config['TEMPLATE'])
+        self.services.info(f'Using template config file {template}')
+
+        if not template.exists():
+            raise RuntimeError(f'{template} config template file does not exist')
+
+        # PLATFORM_CONFIG_FILE is a variable that points to the platform
+        # config file used by the ensembles.  This could be the same
+        # platform config file used for this driver, but it doesn't have to be.
+        platform_config = self.config['PLATFORM_CONFIG_FILE']
+        self.services.info(f'Using platform config file {platform_config}')
+
+        # Specifies different sets of variable values for concurrent ensemble
+        # runs for two different components, 'a_sim_comp' and
+        # 'another_sim_comp', that correspond to two different coupled
+        # simulations.  We chose two components to demonstrate that the same
+        # variable, in this case 'B', can have different values for different
+        # components. 'a_sim_comp' and 'another_sim_comp' are the names of
+        # the config sections in the template file so we know where to look
+        # for variable substitutions.
+        variables = {'a_sim_comp': {'A': [3, 2, 4],
+                                    'B': [2.34, 5.82, 0.1],
+                                    'C': ['bar', 'baz', 'quux']},
+                     'another_sim_comp': {'D': [7, 5, 9],
+                                          'B': [0.775, 0.080, 29.2],
+                                          'F': ['xyzzy', 'plud', 'thud']}}
+
+        # Spins up N tasks, in this case three, each with a different set of
+        # variable values. `mapping` is a data struct that associates the
+        # specific simulation to a given run directory so that the user can
+        # easily find output for a specific run.
+        mapping = self.services.run_ensemble(template,
+                                             variables,
+                                             run_dir,
+                                             platform_config,
+                                             prefix)
+
+        self.services.info(f'Mapping of dirs to parameters: {mapping!s}')
+
+
+    def finalize(self, timeStamp=0.0):
+        return
+

--- a/tests/ensembles/basic/instance_driver.py
+++ b/tests/ensembles/basic/instance_driver.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+    Example driver for the ensembles example.
+
+    Please note that run_ensemble can be run from any IPS component, not
+    just a driver. The driver is used here for simplicity.
+"""
+from pathlib import Path
+
+from ipsframework import Component
+
+
+class instance_driver(Component):
+
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Creating instance driver')
+
+    def init(self, timeStamp=0.0):
+        return
+
+    def step(self, timestamp=0.0, **keywords):
+        """ Run the ensemble instance workers
+
+            In this example we have two components for an
+            example coupled simulation.  The components are
+            'a_sim_comp' and 'another_sim_comp'.  Here, we step
+            each of those components where they echo their
+            unique parameters.
+        """
+        self.services.info('Getting component ports')
+        a_sim_comp = self.services.get_port('A_SIM_COMP')
+        another_sim_comp = self.services.get_port('ANOTHER_SIM_COMP')
+
+        self.services.info('Stepping components')
+        self.services.call(a_sim_comp, 'step', 0.0)
+        self.services.call(another_sim_comp, 'step', 0.0)
+
+        self.services.info('Finished stepping components')
+

--- a/tests/ensembles/basic/mac135909.config
+++ b/tests/ensembles/basic/mac135909.config
@@ -1,0 +1,19 @@
+# Where the source is for my laptop
+SRC_DIR = /Users/may/Projects/IPS
+
+#######################################
+# Parallel environment
+#######################################
+MPIRUN = eval
+NODE_DETECTION = manual
+CORES_PER_NODE = 12
+SOCKETS_PER_NODE = 2
+NODE_ALLOCATION_MODE =  shared
+
+#######################################
+# Provenance
+#######################################
+HOST = localhost
+USER = may
+HOME = $HOME
+SCRATCH = /tmp

--- a/tests/ensembles/basic/template.config
+++ b/tests/ensembles/basic/template.config
@@ -1,0 +1,61 @@
+# Template config file that will be used to generate the ensemble runs. Variables
+# will be substituted from run_ensemble() in the driver script.
+SIM_ROOT = $PWD
+SIM_NAME = ensemble_example_instance
+LOG_FILE = run.log
+LOG_LEVEL = INFO
+SIMULATION_MODE = NORMAL
+
+[PORTS]
+    NAMES = DRIVER A_SIM_COMP ANOTHER_SIM_COMP
+
+    [[DRIVER]]
+        IMPLEMENTATION = driver
+
+    [[A_SIM_COMP]]
+        IMPLEMENTATION = a_sim_comp
+
+    [[ANOTHER_SIM_COMP]]
+        IMPLEMENTATION = another_sim_comp
+
+[driver]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/doc/examples/ensembles/
+    CLASS = driver
+    SUB_CLASS =
+    NAME = instance_driver
+    SCRIPT = ${BIN_PATH}/instance_driver.py
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+
+[a_sim_comp]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/doc/examples/ensembles/
+    CLASS = workers
+    SUB_CLASS =
+    NAME = a_sim_comp
+    SCRIPT = ${BIN_PATH}/a_sim_comp.py
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+    A = ?
+    B = ?
+    C = ?
+
+[another_sim_comp]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/doc/examples/ensembles/
+    CLASS = workers
+    SUB_CLASS =
+    NAME = another_sim_comp
+    SCRIPT = ${BIN_PATH}/another_sim_comp.py
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+    D = ?
+    B = ?
+    F = ?

--- a/tests/ensembles/basic/template.config
+++ b/tests/ensembles/basic/template.config
@@ -20,7 +20,7 @@ SIMULATION_MODE = NORMAL
 
 [driver]
     # SRC_DIR specified in platform config
-    BIN_PATH = $SRC_DIR/IPS-framework/doc/examples/ensembles/
+    BIN_PATH = $SRC_DIR/IPS-framework/tests/ensembles/basic/
     CLASS = driver
     SUB_CLASS =
     NAME = instance_driver
@@ -32,7 +32,7 @@ SIMULATION_MODE = NORMAL
 
 [a_sim_comp]
     # SRC_DIR specified in platform config
-    BIN_PATH = $SRC_DIR/IPS-framework/doc/examples/ensembles/
+    BIN_PATH = $SRC_DIR/IPS-framework/tests/ensembles/basic/
     CLASS = workers
     SUB_CLASS =
     NAME = a_sim_comp

--- a/tests/ensembles/extra-variable/a_sim_comp.py
+++ b/tests/ensembles/extra-variable/a_sim_comp.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+""" Component wrapper for the ensemble example for `a_sim`. """
+from ipsframework import Component
+
+
+class a_sim_comp(Component):
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Created %s' % (self.__class__))
+
+    def step(self, timestamp=0.0):
+        # TODO echo parameters for this run
+        print('Hello from a_sim_comp')
+
+        # Echo the parameters we're expecting, A, B, and C
+        print(f'a_sim_comp parameters: A={self.A}, B={self.B}, C={self.C}')

--- a/tests/ensembles/extra-variable/another_sim_comp.py
+++ b/tests/ensembles/extra-variable/another_sim_comp.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+""" Component wrapper for the ensemble example for `another_sim`. """
+from ipsframework import Component
+
+
+class another_sim_comp(Component):
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Created %s' % (self.__class__))
+
+    def step(self, timestamp=0.0):
+        # TODO echo parameters for this run
+        print('Hello from another_sim_comp')
+
+        # Echo the parameters we're expecting, D, B, and F
+        print(f'another_sim_comp parameters: D={self.D}, B={self.B}, F={self.F}')

--- a/tests/ensembles/extra-variable/driver.config
+++ b/tests/ensembles/extra-variable/driver.config
@@ -1,0 +1,31 @@
+# Example configuration file for ensemble support
+
+SIM_ROOT = $PWD
+SIM_NAME = ensemble_example
+ENSEMBLE_DIR = /tmp/ensembles
+ENSEMBLE_PREFIX = MY_INSTANCE_
+LOG_FILE = run.log
+LOG_LEVEL = INFO
+SIMULATION_MODE = NORMAL
+
+[PORTS]
+    NAMES = DRIVER
+
+    [[DRIVER]]
+        IMPLEMENTATION = driver
+
+[driver]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/tests/ensembles/extra-variable/
+    CLASS = driver
+    SUB_CLASS =
+    NAME = ensemble_driver
+    SCRIPT = ${BIN_PATH}/driver.py
+    TEMPLATE = ${BIN_PATH}/template.config
+    PLATFORM_CONFIG_FILE = ${BIN_PATH}/mac135909.config
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+
+

--- a/tests/ensembles/extra-variable/driver.py
+++ b/tests/ensembles/extra-variable/driver.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+    Example driver for the ensembles example.
+
+    Please note that run_ensemble can be run from any IPS component, not
+    just a driver. The driver is used here for simplicity.
+"""
+from pathlib import Path
+
+from ipsframework import Component
+
+
+class ensemble_driver(Component):
+
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Creating driver')
+
+    def init(self, timeStamp=0.0):
+        return
+
+    def step(self, timestamp=0.0, **keywords):
+        """ set up and run the ensemble
+        """
+        # ENSEMBLE_DIR is an arbitrary variable denoting where we want to run
+        # all the ensembles.  You don't have to use ENSEMBLE_DIR. You can
+        # even hardcode the path here.  Whatever.
+        run_dir = Path(self.services.get_config_param('ENSEMBLE_DIR'))
+        self.services.info(f'Running ensemble in {run_dir}')
+
+        # ENSEMBLE_PREFIX is an optional config variable for specifying
+        # a string to prepend to the ensemble run directories and generated
+        # files.  If not specified, the default is 'INSTANCE_n' where n is
+        # is the arbitrary instance ID.
+        prefix = self.services.get_config_param('ENSEMBLE_PREFIX',
+                                                silent=True)
+        if not prefix or prefix == '' or prefix == {}:
+            self.services.info('No ensemble instance prefix specified. Using '
+                               'default of INSTANCE_.')
+            prefix = "INSTANCE_"
+        else:
+            self.services.info(f'Using ensemble instance prefix {prefix}')
+
+        if not run_dir.exists():
+            self.services.info(f'Creating {run_dir}')
+            run_dir.mkdir(parents=True)
+
+        template = Path(self.config['TEMPLATE'])
+        self.services.info(f'Using template config file {template}')
+
+        if not template.exists():
+            raise RuntimeError(f'{template} config template file does not exist')
+
+        # PLATFORM_CONFIG_FILE is a variable that points to the platform
+        # config file used by the ensembles.  This could be the same
+        # platform config file used for this driver, but it doesn't have to be.
+        platform_config = self.config['PLATFORM_CONFIG_FILE']
+        self.services.info(f'Using platform config file {platform_config}')
+
+        # Specifies different sets of variable values for concurrent ensemble
+        # runs for two different components, 'a_sim_comp' and
+        # 'another_sim_comp', that correspond to two different coupled
+        # simulations.  We chose two components to demonstrate that the same
+        # variable, in this case 'B', can have different values for different
+        # components. 'a_sim_comp' and 'another_sim_comp' are the names of
+        # the config sections in the template file so we know where to look
+        # for variable substitutions.
+        variables = {'a_sim_comp': {'A': [3, 2, 4],
+                                    'B': [2.34, 5.82, 0.1],
+                                    'C': ['bar', 'baz', 'quux']},
+                     'another_sim_comp': {'D': [7, 5, 9],
+                                          'B': [0.775, 0.080, 29.2],
+                                          'F': ['xyzzy', 'plud', 'thud']}}
+
+        # Spins up N tasks, in this case three, each with a different set of
+        # variable values. `mapping` is a data struct that associates the
+        # specific simulation to a given run directory so that the user can
+        # easily find output for a specific run.
+        mapping = self.services.run_ensemble(template,
+                                             variables,
+                                             run_dir,
+                                             platform_config,
+                                             prefix)
+
+        self.services.info(f'Mapping of dirs to parameters: {mapping!s}')
+
+
+    def finalize(self, timeStamp=0.0):
+        return
+

--- a/tests/ensembles/extra-variable/instance_driver.py
+++ b/tests/ensembles/extra-variable/instance_driver.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+    Example driver for the ensembles example.
+
+    Please note that run_ensemble can be run from any IPS component, not
+    just a driver. The driver is used here for simplicity.
+"""
+from pathlib import Path
+
+from ipsframework import Component
+
+
+class instance_driver(Component):
+
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Creating instance driver')
+
+    def init(self, timeStamp=0.0):
+        return
+
+    def step(self, timestamp=0.0, **keywords):
+        """ Run the ensemble instance workers
+
+            In this example we have two components for an
+            example coupled simulation.  The components are
+            'a_sim_comp' and 'another_sim_comp'.  Here, we step
+            each of those components where they echo their
+            unique parameters.
+        """
+        self.services.info('Getting component ports')
+        a_sim_comp = self.services.get_port('A_SIM_COMP')
+        another_sim_comp = self.services.get_port('ANOTHER_SIM_COMP')
+
+        self.services.info('Stepping components')
+        self.services.call(a_sim_comp, 'step', 0.0)
+        self.services.call(another_sim_comp, 'step', 0.0)
+
+        self.services.info('Finished stepping components')
+

--- a/tests/ensembles/extra-variable/mac135909.config
+++ b/tests/ensembles/extra-variable/mac135909.config
@@ -1,0 +1,19 @@
+# Where the source is for my laptop
+SRC_DIR = /Users/may/Projects/IPS
+
+#######################################
+# Parallel environment
+#######################################
+MPIRUN = eval
+NODE_DETECTION = manual
+CORES_PER_NODE = 12
+SOCKETS_PER_NODE = 2
+NODE_ALLOCATION_MODE =  shared
+
+#######################################
+# Provenance
+#######################################
+HOST = localhost
+USER = may
+HOME = $HOME
+SCRATCH = /tmp

--- a/tests/ensembles/extra-variable/template.config
+++ b/tests/ensembles/extra-variable/template.config
@@ -1,0 +1,62 @@
+# Template config file that will be used to generate the ensemble runs. Variables
+# will be substituted from run_ensemble() in the driver script.
+SIM_ROOT = $PWD
+SIM_NAME = ensemble_example_instance
+LOG_FILE = run.log
+LOG_LEVEL = INFO
+SIMULATION_MODE = NORMAL
+
+[PORTS]
+    NAMES = DRIVER A_SIM_COMP ANOTHER_SIM_COMP
+
+    [[DRIVER]]
+        IMPLEMENTATION = driver
+
+    [[A_SIM_COMP]]
+        IMPLEMENTATION = a_sim_comp
+
+    [[ANOTHER_SIM_COMP]]
+        IMPLEMENTATION = another_sim_comp
+
+[driver]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/tests/ensembles/extra-variable/
+    CLASS = driver
+    SUB_CLASS =
+    NAME = instance_driver
+    SCRIPT = ${BIN_PATH}/instance_driver.py
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+
+[a_sim_comp]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/tests/ensembles/extra-variable/
+    CLASS = workers
+    SUB_CLASS =
+    NAME = a_sim_comp
+    SCRIPT = ${BIN_PATH}/a_sim_comp.py
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+    A = ?
+    B = ?
+    C = ?
+
+[another_sim_comp]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/doc/examples/ensembles/
+    CLASS = workers
+    SUB_CLASS =
+    NAME = another_sim_comp
+    SCRIPT = ${BIN_PATH}/another_sim_comp.py
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+    D = ?
+    B = ?
+    F = ?
+    Z = ? # this is an EXTRA VARIABLE that should yield an error

--- a/tests/ensembles/missing-assignment/a_sim_comp.py
+++ b/tests/ensembles/missing-assignment/a_sim_comp.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+""" Component wrapper for the ensemble example for `a_sim`. """
+from ipsframework import Component
+
+
+class a_sim_comp(Component):
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Created %s' % (self.__class__))
+
+    def step(self, timestamp=0.0):
+        # TODO echo parameters for this run
+        print('Hello from a_sim_comp')
+
+        # Echo the parameters we're expecting, A, B, and C
+        print(f'a_sim_comp parameters: A={self.A}, B={self.B}, C={self.C}')

--- a/tests/ensembles/missing-assignment/another_sim_comp.py
+++ b/tests/ensembles/missing-assignment/another_sim_comp.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+""" Component wrapper for the ensemble example for `another_sim`. """
+from ipsframework import Component
+
+
+class another_sim_comp(Component):
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Created %s' % (self.__class__))
+
+    def step(self, timestamp=0.0):
+        # TODO echo parameters for this run
+        print('Hello from another_sim_comp')
+
+        # Echo the parameters we're expecting, D, B, and F
+        print(f'another_sim_comp parameters: D={self.D}, B={self.B}, F={self.F}')

--- a/tests/ensembles/missing-assignment/driver.config
+++ b/tests/ensembles/missing-assignment/driver.config
@@ -1,0 +1,31 @@
+# Example configuration file for ensemble support
+
+SIM_ROOT = $PWD
+SIM_NAME = ensemble_example
+ENSEMBLE_DIR = /tmp/ensembles
+ENSEMBLE_PREFIX = MY_INSTANCE_
+LOG_FILE = run.log
+LOG_LEVEL = INFO
+SIMULATION_MODE = NORMAL
+
+[PORTS]
+    NAMES = DRIVER
+
+    [[DRIVER]]
+        IMPLEMENTATION = driver
+
+[driver]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/tests/ensembles/missing-assignment/
+    CLASS = driver
+    SUB_CLASS =
+    NAME = ensemble_driver
+    SCRIPT = ${BIN_PATH}/driver.py
+    TEMPLATE = ${BIN_PATH}/template.config
+    PLATFORM_CONFIG_FILE = ${BIN_PATH}/mac135909.config
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+
+

--- a/tests/ensembles/missing-assignment/driver.py
+++ b/tests/ensembles/missing-assignment/driver.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+    Example driver for the ensembles example.
+
+    Please note that run_ensemble can be run from any IPS component, not
+    just a driver. The driver is used here for simplicity.
+"""
+from pathlib import Path
+
+from ipsframework import Component
+
+
+class ensemble_driver(Component):
+
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Creating driver')
+
+    def init(self, timeStamp=0.0):
+        return
+
+    def step(self, timestamp=0.0, **keywords):
+        """ set up and run the ensemble
+        """
+        # ENSEMBLE_DIR is an arbitrary variable denoting where we want to run
+        # all the ensembles.  You don't have to use ENSEMBLE_DIR. You can
+        # even hardcode the path here.  Whatever.
+        run_dir = Path(self.services.get_config_param('ENSEMBLE_DIR'))
+        self.services.info(f'Running ensemble in {run_dir}')
+
+        # ENSEMBLE_PREFIX is an optional config variable for specifying
+        # a string to prepend to the ensemble run directories and generated
+        # files.  If not specified, the default is 'INSTANCE_n' where n is
+        # is the arbitrary instance ID.
+        prefix = self.services.get_config_param('ENSEMBLE_PREFIX',
+                                                silent=True)
+        if not prefix or prefix == '' or prefix == {}:
+            self.services.info('No ensemble instance prefix specified. Using '
+                               'default of INSTANCE_.')
+            prefix = "INSTANCE_"
+        else:
+            self.services.info(f'Using ensemble instance prefix {prefix}')
+
+        if not run_dir.exists():
+            self.services.info(f'Creating {run_dir}')
+            run_dir.mkdir(parents=True)
+
+        template = Path(self.config['TEMPLATE'])
+        self.services.info(f'Using template config file {template}')
+
+        if not template.exists():
+            raise RuntimeError(f'{template} config template file does not exist')
+
+        # PLATFORM_CONFIG_FILE is a variable that points to the platform
+        # config file used by the ensembles.  This could be the same
+        # platform config file used for this driver, but it doesn't have to be.
+        platform_config = self.config['PLATFORM_CONFIG_FILE']
+        self.services.info(f'Using platform config file {platform_config}')
+
+        # Specifies different sets of variable values for concurrent ensemble
+        # runs for two different components, 'a_sim_comp' and
+        # 'another_sim_comp', that correspond to two different coupled
+        # simulations.  We chose two components to demonstrate that the same
+        # variable, in this case 'B', can have different values for different
+        # components. 'a_sim_comp' and 'another_sim_comp' are the names of
+        # the config sections in the template file so we know where to look
+        # for variable substitutions.
+        variables = {'a_sim_comp': {'A': [3, 2, 4],
+                                    'B': [2.34, 5.82, 0.1],
+                                    'C': ['bar', 'baz', 'quux']},
+                     'another_sim_comp': {'D': [7, 5, 9],
+                                          'B': [0.775, 0.080, 29.2],
+                                          'F': ['xyzzy', 'plud', 'thud']}}
+
+        # Spins up N tasks, in this case three, each with a different set of
+        # variable values. `mapping` is a data struct that associates the
+        # specific simulation to a given run directory so that the user can
+        # easily find output for a specific run.
+        mapping = self.services.run_ensemble(template,
+                                             variables,
+                                             run_dir,
+                                             platform_config,
+                                             prefix)
+
+        self.services.info(f'Mapping of dirs to parameters: {mapping!s}')
+
+
+    def finalize(self, timeStamp=0.0):
+        return
+

--- a/tests/ensembles/missing-assignment/instance_driver.py
+++ b/tests/ensembles/missing-assignment/instance_driver.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+    Example driver for the ensembles example.
+
+    Please note that run_ensemble can be run from any IPS component, not
+    just a driver. The driver is used here for simplicity.
+"""
+from pathlib import Path
+
+from ipsframework import Component
+
+
+class instance_driver(Component):
+
+    def __init__(self, services, config):
+        super().__init__(services, config)
+        print('Creating instance driver')
+
+    def init(self, timeStamp=0.0):
+        return
+
+    def step(self, timestamp=0.0, **keywords):
+        """ Run the ensemble instance workers
+
+            In this example we have two components for an
+            example coupled simulation.  The components are
+            'a_sim_comp' and 'another_sim_comp'.  Here, we step
+            each of those components where they echo their
+            unique parameters.
+        """
+        self.services.info('Getting component ports')
+        a_sim_comp = self.services.get_port('A_SIM_COMP')
+        another_sim_comp = self.services.get_port('ANOTHER_SIM_COMP')
+
+        self.services.info('Stepping components')
+        self.services.call(a_sim_comp, 'step', 0.0)
+        self.services.call(another_sim_comp, 'step', 0.0)
+
+        self.services.info('Finished stepping components')
+

--- a/tests/ensembles/missing-assignment/mac135909.config
+++ b/tests/ensembles/missing-assignment/mac135909.config
@@ -1,0 +1,19 @@
+# Where the source is for my laptop
+SRC_DIR = /Users/may/Projects/IPS
+
+#######################################
+# Parallel environment
+#######################################
+MPIRUN = eval
+NODE_DETECTION = manual
+CORES_PER_NODE = 12
+SOCKETS_PER_NODE = 2
+NODE_ALLOCATION_MODE =  shared
+
+#######################################
+# Provenance
+#######################################
+HOST = localhost
+USER = may
+HOME = $HOME
+SCRATCH = /tmp

--- a/tests/ensembles/missing-assignment/template.config
+++ b/tests/ensembles/missing-assignment/template.config
@@ -41,7 +41,8 @@ SIMULATION_MODE = NORMAL
     INPUT_FILES =
     OUTPUT_FILES =
     RESTART_FILES =
-    A = ?
+    # Intentionally make A with no '?' or value
+    A =
     # B is intentionally missing
     C = ?
 

--- a/tests/ensembles/missing-assignment/template.config
+++ b/tests/ensembles/missing-assignment/template.config
@@ -1,0 +1,61 @@
+# Template config file that will be used to generate the ensemble runs. Variables
+# will be substituted from run_ensemble() in the driver script.
+SIM_ROOT = $PWD
+SIM_NAME = ensemble_missing_assignment
+LOG_FILE = run.log
+LOG_LEVEL = INFO
+SIMULATION_MODE = NORMAL
+
+[PORTS]
+    NAMES = DRIVER A_SIM_COMP ANOTHER_SIM_COMP
+
+    [[DRIVER]]
+        IMPLEMENTATION = driver
+
+    [[A_SIM_COMP]]
+        IMPLEMENTATION = a_sim_comp
+
+    [[ANOTHER_SIM_COMP]]
+        IMPLEMENTATION = another_sim_comp
+
+[driver]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/tests/ensembles/missing-assignment/
+    CLASS = driver
+    SUB_CLASS =
+    NAME = instance_driver
+    SCRIPT = ${BIN_PATH}/instance_driver.py
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+
+[a_sim_comp]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/tests/ensembles/missing-assignment/
+    CLASS = workers
+    SUB_CLASS =
+    NAME = a_sim_comp
+    SCRIPT = ${BIN_PATH}/a_sim_comp.py
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+    A = ?
+    # B is intentionally missing
+    C = ?
+
+[another_sim_comp]
+    # SRC_DIR specified in platform config
+    BIN_PATH = $SRC_DIR/IPS-framework/tests/ensembles/missing-assignment/
+    CLASS = workers
+    SUB_CLASS =
+    NAME = another_sim_comp
+    SCRIPT = ${BIN_PATH}/another_sim_comp.py
+    NPROC = 1
+    INPUT_FILES =
+    OUTPUT_FILES =
+    RESTART_FILES =
+    D = ?
+    B = ?
+    F = ?


### PR DESCRIPTION
These changes add the following checks, which can be found in `./tests/ensembles`:

In the template config file, if a variable to be substituted is:
- blank and does not have a '?' indicating it needs to be filled in, issue a warning, substituted anyway, and move on (it's likely the user just forgot to put in the '?')
- already has an assigned value (that is a scalar that's not '?'), complain with CRITICAL error and raise exception
- not present in the template file, complain with CRITICAL error and raise exception
- missing, complain with CRITICAL error and raise exception
- in the template config file but not given values by the user, complain with CRITICAL error and raise exception