### PR TITLE
209 - ensure web portal flexibility

### DIFF
--- a/ipsframework/portalBridge.py
+++ b/ipsframework/portalBridge.py
@@ -234,7 +234,7 @@ class PortalBridge(Component):
             self.dump_freq = freq
 
         try:
-            self.html_dir = self.services.get_config_param('USER_W3_DIR', silent=True)
+            self.html_dir = self.services.get_config_param('USER_W3_DIR', silent=True) or ''
         except Exception:
             self.services.warning('Missing USER_W3_DIR configuration - disabling web-visible logging')
             self.write_to_htmldir = False

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -901,7 +901,7 @@ class ServicesProxy:
 
         return task_id
 
-    def _launch_task(self, nproc: int, working_dir: str, task_id, command, cores_allocated, env_update, tag, keywords, binary: str, *args):
+    def _launch_task(self, nproc: int, working_dir: str, task_id, command, cores_allocated, env_update, tag, keywords, binary: str, args: Union[list[str], tuple[str, ...]]):
         log_filename = keywords.get('logfile')
         timeout = keywords.get('timeout', 1.0e9)
 

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2417,6 +2417,16 @@ class ServicesProxy:
             # by setting SIM_ROOT to the prefix path.
             template['SIM_ROOT'] = Path(working_dir)
 
+            # Handle portal configuration, note that PORTAL_API_KEY should be an environment variable and will be passed in later.
+            portal_runid = self.get_config_param('PORTAL_RUNID', silent=True)
+            portal_url = self.get_config_param('PORTAL_URL', silent=True)
+            if portal_runid and portal_url:
+                template['PORTAL_URL'] = portal_url
+                template['USE_PORTAL'] = 'True'
+                template['PARENT_PORTAL_RUNID'] = portal_runid
+            else:
+                template['USE_PORTAL'] = 'False'
+
             # We need to plug in the variables, so we need to find the section
             # for a each component, and then find the corresponding variables
             # to then assign the associated value.
@@ -2537,14 +2547,6 @@ class ServicesProxy:
             # define node allocation mode to be shared since we'll have more
             # than one ensemble instance per node.
             platform_config['NODE_ALLOCATION_MODE'] = 'SHARED'
-
-            # inherit the portal information from the top-level
-            portal_url = self.get_config_param('PORTAL_URL', silent=True)
-            if portal_url:
-                platform_config['USE_PORTAL'] = 'True'
-            else:  # None specified, so we're going to have it default to False
-                # This turns off logging for the portal
-                platform_config['USE_PORTAL'] = 'False'
 
             platform_config.write()
 


### PR DESCRIPTION
This MR adds a few small changes:

- fixes an issue where, in the event that the portal was enabled but the `USER_W3_DIR` variable was not defined, the configuration value would be set to None instead of an empty string, but string methods would be called on the variable.

- makes sure that all portal information gets passed through the ensemble API automatically. I moved this from the platform config file to the simulation config file (since, historically, the portal has always been configured in the simulation file), but I also don't see an issue with configuring it in the platform file if that's desired.

- also fixes a mistaken typing instance in the `_launch_instance` function, where `args` (which is just a list or tuple of strings i.e. command line args) was cast as `*args`. (This causes a runtime error.)