### PR TITLE
228 hwloc xmlfile openmpi dvm hack

### DIFF
--- a/examples-proposed/022-tasks-and-ensembles/driver.py
+++ b/examples-proposed/022-tasks-and-ensembles/driver.py
@@ -47,8 +47,8 @@ class EnsembleDriver(Component):
                                              run_dir=Path('.').absolute(),
                                              name='INSTANCE_',
                                              num_nodes=1,
-                                             cores_per_instance=10,
-                                             oversubscribe=True)
+                                             cores_per_instance=5,
+                                             oversubscribe=False)
         # Print each mapping of instance name to what variable values were used.
         for instance in mapping:
             self.services.info(f'{instance!s}')

--- a/examples-proposed/022-tasks-and-ensembles/perlmutter.slurm
+++ b/examples-proposed/022-tasks-and-ensembles/perlmutter.slurm
@@ -12,15 +12,15 @@
 #SBATCH --time=5
 #SBATCH -p debug
 
-# This sets the absolute path to the mpi_stats.py script, which is used by IPS to
-export MPI_STATS_EXEC=$(realpath ./mpi_stats.py)
-
-echo "Using MPI_STATS_EXEC: ${MPI_STATS_EXEC}"
-
 module load PrgEnv-gnu openmpi python
 
 # Again, this assumes that there exists a conda environment named "ips".
 conda activate ips
+
+# This sets the absolute path to the mpi_stats.py script, which is used by IPS to
+export MPI_STATS_EXEC=$(realpath ./mpi_stats.py)
+
+echo "Using MPI_STATS_EXEC: ${MPI_STATS_EXEC}"
 
 # The 2>&1 binds stderr to stdout so that both are captured in the tee log file.  The
 # `tee` command allows you to see the output on the terminal as well as save it.

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2660,6 +2660,7 @@ class DVMPlugin(WorkerPlugin):
         self.logger.info(f'Launching DVM')
         self.worker.dvm_uri_file = f'/tmp/dvm.uri.{os.getpid()}'
         command = ['srun', '--mpi=pmix', '-N', os.environ['SLURM_NNODES'],
+                   '--ntasks-per-node=1', 'prte', '--daemonize',
                    '--report-uri', self.worker.dvm_uri_file]
 
         mapping_policy = 'core'  # by default bind to cores

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2690,6 +2690,8 @@ class DVMPlugin(WorkerPlugin):
 
         if 'HWLOC_XMLFILE' in os.environ:
             # Remove HWLOC_XMLFILE to avoid issues with OpenMPI on Dask workers
+            self.logger.debug('Removing HWLOC_XMLFILE environment variable for '
+                              'Dask worker')
             del os.environ['HWLOC_XMLFILE']
 
         return

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -139,19 +139,23 @@ def launch(binary: Any, task_name: str, working_dir: Union[str, os.PathLike], *a
                 worker.logger.info(f'Using DVM URI file: {dvm_uri_file}')
                 print(f'Using DVM URI file: {dvm_uri_file}', flush=True)
 
+        # PMIX_SERVER_URI41 is used by prun to figure out how to talk to the DVM
+        # It can be defined in `task_env` or in `os.environ`, so we look in
+        # both locations to just echo its presence. The flushes are necessary
+        # in some HPC environments to ensure the output appears in the logs.
         if task_env is not None and task_env is not {}:
-            if not 'PMIX_SERVER_URI41' in task_env:
-                worker.logger.error('DVM environment variable PMIX_SERVER_URI41 not set in task_env')
-                print('DVM environment variable PMIX_SERVER_URI41 not set in task_env', flush=True)
-            else:
-                worker.logger.info(f"DVM environment variable PMIX_SERVER_URI41 set in task_env to {{task_env['PMIX_SERVER_URI41']}}")
-                print(f'DVM environment variable PMIX_SERVER_URI41 set in task_env to {task_env["PMIX_SERVER_URI41"]}', flush=True)
-        if not 'PMIX_SERVER_URI41' in os.environ:
-            worker.logger.error('DVM environment variable PMIX_SERVER_URI41 not set in os.environ')
-            print('DVM environment variable PMIX_SERVER_URI41 not set in os.environ', flush=True)
-        else:
-            worker.logger.info(f"DVM environment variable PMIX_SERVER_URI41 set in os.environ to {{os.environ['PMIX_SERVER_URI41']}}")
-            print(f'DVM environment variable PMIX_SERVER_URI41 set in os.environ to {os.environ["PMIX_SERVER_URI41"]}', flush=True)
+            if 'PMIX_SERVER_URI41' in task_env:
+                worker.logger.info(f"DVM environment variable PMIX_SERVER_URI41 "
+                                   f"set in task_env to "
+                                   f"{task_env['PMIX_SERVER_URI41']}")
+                print(f'DVM environment variable PMIX_SERVER_URI41 set in task_'
+                      f'env to {task_env["PMIX_SERVER_URI41"]}', flush=True)
+        if 'PMIX_SERVER_URI41' in os.environ:
+            worker.logger.info(f"DVM environment variable PMIX_SERVER_URI41 set "
+                               f"in os.environ to "
+                               f"{os.environ['PMIX_SERVER_URI41']}")
+            print(f'DVM environment variable PMIX_SERVER_URI41 set in os.environ '
+                  f'to {os.environ["PMIX_SERVER_URI41"]}', flush=True)
 
         timeout = float(keywords.get('timeout', 1.0e9))
 
@@ -2645,14 +2649,12 @@ class DVMPlugin(WorkerPlugin):
         """
         self.worker = worker
         worker.logger = self.logger
-        # FIXME this is a temporary hack to ensure that the logger honors
-        # debug messages.  I don't know why this is otherwise being
-        # ignored when specifying --debug on the command line.  I am
-        # invoking client.forward_logging() elsewhere, so I shouldn't have to
-        # do this.
-        self.logger.setLevel(logging.DEBUG)
+
+        if 'HWLOC_XMLFILE' in os.environ:
+            # Remove HWLOC_XMLFILE to avoid issues with OpenMPI on Dask workers
+            del os.environ['HWLOC_XMLFILE']
+
         self.logger.info(f'Launching DVM')
-        # TODO could make this more OS agnostic by using tempfile.mkstemp
         self.worker.dvm_uri_file = f'/tmp/dvm.uri.{os.getpid()}'
         command = ['prte', '--report-uri', self.worker.dvm_uri_file]
 

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -129,6 +129,10 @@ def launch(binary: Any, task_name: str, working_dir: Union[str, os.PathLike], *a
         new_env = os.environ.copy()
         new_env.update(task_env)
 
+        if 'HWLOC_XMLFILE' in new_env:
+            worker.logger.debug('Removing HWLOC_XMLFILE from task environment')
+            del new_env['HWLOC_XMLFILE']
+
         # Check that the DVM environment variables are set.
         if hasattr(worker, 'dvm_uri_file'):
             dvm_uri_file = Path(worker.dvm_uri_file)
@@ -136,7 +140,7 @@ def launch(binary: Any, task_name: str, working_dir: Union[str, os.PathLike], *a
                 worker.logger.error(f'DVM URI file {dvm_uri_file} does not exist')
                 print(f'DVM URI file {dvm_uri_file} does not exist', flush=True)
             else:
-                worker.logger.info(f'Using DVM URI file: {dvm_uri_file}')
+                worker.logger.debug(f'Using DVM URI file: {dvm_uri_file}')
                 print(f'Using DVM URI file: {dvm_uri_file}', flush=True)
 
         # PMIX_SERVER_URI41 is used by prun to figure out how to talk to the DVM
@@ -145,13 +149,13 @@ def launch(binary: Any, task_name: str, working_dir: Union[str, os.PathLike], *a
         # in some HPC environments to ensure the output appears in the logs.
         if task_env is not None and task_env is not {}:
             if 'PMIX_SERVER_URI41' in task_env:
-                worker.logger.info(f"DVM environment variable PMIX_SERVER_URI41 "
+                worker.logger.debug(f"DVM environment variable PMIX_SERVER_URI41 "
                                    f"set in task_env to "
                                    f"{task_env['PMIX_SERVER_URI41']}")
                 print(f'DVM environment variable PMIX_SERVER_URI41 set in task_'
                       f'env to {task_env["PMIX_SERVER_URI41"]}', flush=True)
         if 'PMIX_SERVER_URI41' in os.environ:
-            worker.logger.info(f"DVM environment variable PMIX_SERVER_URI41 set "
+            worker.logger.debug(f"DVM environment variable PMIX_SERVER_URI41 set "
                                f"in os.environ to "
                                f"{os.environ['PMIX_SERVER_URI41']}")
             print(f'DVM environment variable PMIX_SERVER_URI41 set in os.environ '
@@ -171,7 +175,10 @@ def launch(binary: Any, task_name: str, working_dir: Union[str, os.PathLike], *a
 
         cmd_lst = cmd.split()
         try:
-            process = subprocess.Popen(cmd_lst, stdout=task_stdout, stderr=task_stderr, cwd=working_dir, preexec_fn=os.setsid, env=new_env)  # noqa: PLW1509 (TODO: look into this to potentially avoid deadlocks)
+            process = subprocess.Popen(cmd_lst, stdout=task_stdout,
+                                       stderr=task_stderr,
+                                       cwd=working_dir,
+                                       preexec_fn=os.setsid, env=new_env)  # noqa: PLW1509 (TODO: look into this to potentially avoid deadlocks)
         except Exception as e:
             with worker.lock:
                 print(
@@ -2650,10 +2657,6 @@ class DVMPlugin(WorkerPlugin):
         self.worker = worker
         worker.logger = self.logger
 
-        if 'HWLOC_XMLFILE' in os.environ:
-            # Remove HWLOC_XMLFILE to avoid issues with OpenMPI on Dask workers
-            del os.environ['HWLOC_XMLFILE']
-
         self.logger.info(f'Launching DVM')
         self.worker.dvm_uri_file = f'/tmp/dvm.uri.{os.getpid()}'
         command = ['prte', '--report-uri', self.worker.dvm_uri_file]
@@ -2671,7 +2674,8 @@ class DVMPlugin(WorkerPlugin):
         # This environment variable is specific to OpenMPI's PRTE
         os.environ['PRTE_MCA_rmaps_default_mapping_policy'] = mapping_policy
 
-        self.worker.dvm_proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        self.worker.dvm_proc = subprocess.Popen(command, stdout=subprocess.PIPE,
+                                                stderr=subprocess.STDOUT)
 
         ready = self.worker.dvm_proc.stdout.readline()
         self.logger.info(f'Ready Message : {ready}')
@@ -2683,6 +2687,10 @@ class DVMPlugin(WorkerPlugin):
             self.logger.debug(f'Read DVM URI: {self.worker.dvm_uri}')
 
         os.environ['PMIX_SERVER_URI41'] = self.worker.dvm_uri
+
+        if 'HWLOC_XMLFILE' in os.environ:
+            # Remove HWLOC_XMLFILE to avoid issues with OpenMPI on Dask workers
+            del os.environ['HWLOC_XMLFILE']
 
         return
 

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2659,8 +2659,8 @@ class DVMPlugin(WorkerPlugin):
 
         self.logger.info(f'Launching DVM')
         self.worker.dvm_uri_file = f'/tmp/dvm.uri.{os.getpid()}'
-        command = ['srun', '--mpi=pmix_v4', '-N', os.environ['SLURM_NNODES'],
-                   '--ntasks-per-node=1', 'prte', #'--no-daemonize',
+        command = [#'srun', '--mpi=pmix_v4', '-N', os.environ['SLURM_NNODES'], '--ntasks-per-node=1',
+                   'prte', #'--no-daemonize',
                    '--report-uri', self.worker.dvm_uri_file]
 
         mapping_policy = 'core'  # by default bind to cores

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2663,6 +2663,9 @@ class DVMPlugin(WorkerPlugin):
             self.logger.debug('HWLOC_XMLFILE environment variable not set '
                               'for Dask worker')
 
+        # Necessary to ensure the DVM "sees" all the resources to manage
+        os.environ['PRTE_MCA_ras_slurm_use_entire_allocation'] = "1"
+
         self.worker = worker
         worker.logger = self.logger
 

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2659,8 +2659,8 @@ class DVMPlugin(WorkerPlugin):
 
         self.logger.info(f'Launching DVM')
         self.worker.dvm_uri_file = f'/tmp/dvm.uri.{os.getpid()}'
-        command = ['srun', '--mpi=pmix', '-N', os.environ['SLURM_NNODES'],
-                   '--ntasks-per-node=1', 'prte', '--no-daemonize',
+        command = ['srun', '--mpi=pmix_v4', '-N', os.environ['SLURM_NNODES'],
+                   '--ntasks-per-node=1', 'prte', #'--no-daemonize',
                    '--report-uri', self.worker.dvm_uri_file]
 
         mapping_policy = 'core'  # by default bind to cores

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2654,6 +2654,12 @@ class DVMPlugin(WorkerPlugin):
         :param oversubscribe: Whether to allow oversubscription of nodes
             when launching the ensemble runs. Default is False.
         """
+        if 'HWLOC_XMLFILE' in os.environ:
+            # Remove HWLOC_XMLFILE to avoid issues with OpenMPI on Dask workers
+            self.logger.debug('Removing HWLOC_XMLFILE environment variable for '
+                              'Dask worker')
+            del os.environ['HWLOC_XMLFILE']
+
         self.worker = worker
         worker.logger = self.logger
 
@@ -2690,11 +2696,7 @@ class DVMPlugin(WorkerPlugin):
 
         os.environ['PMIX_SERVER_URI41'] = self.worker.dvm_uri
 
-        if 'HWLOC_XMLFILE' in os.environ:
-            # Remove HWLOC_XMLFILE to avoid issues with OpenMPI on Dask workers
-            self.logger.debug('Removing HWLOC_XMLFILE environment variable for '
-                              'Dask worker')
-            del os.environ['HWLOC_XMLFILE']
+
 
         return
 

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2659,6 +2659,9 @@ class DVMPlugin(WorkerPlugin):
             self.logger.debug('Removing HWLOC_XMLFILE environment variable for '
                               'Dask worker')
             del os.environ['HWLOC_XMLFILE']
+        else:
+            self.logger.debug('HWLOC_XMLFILE environment variable not set '
+                              'for Dask worker')
 
         self.worker = worker
         worker.logger = self.logger

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2659,7 +2659,8 @@ class DVMPlugin(WorkerPlugin):
 
         self.logger.info(f'Launching DVM')
         self.worker.dvm_uri_file = f'/tmp/dvm.uri.{os.getpid()}'
-        command = ['prte', '--report-uri', self.worker.dvm_uri_file]
+        command = ['srun', '--mpi=pmix', '-N', os.environ['SLURM_NNODES'],
+                   '--report-uri', self.worker.dvm_uri_file]
 
         mapping_policy = 'core'  # by default bind to cores
         if self.hwthreads:

--- a/ipsframework/services.py
+++ b/ipsframework/services.py
@@ -2660,7 +2660,7 @@ class DVMPlugin(WorkerPlugin):
         self.logger.info(f'Launching DVM')
         self.worker.dvm_uri_file = f'/tmp/dvm.uri.{os.getpid()}'
         command = ['srun', '--mpi=pmix', '-N', os.environ['SLURM_NNODES'],
-                   '--ntasks-per-node=1', 'prte', '--daemonize',
+                   '--ntasks-per-node=1', 'prte', '--no-daemonize',
                    '--report-uri', self.worker.dvm_uri_file]
 
         mapping_policy = 'core'  # by default bind to cores


### PR DESCRIPTION
Now able to spin up instances without need for explicit oversubscription.

- ensured the environment variable `HWLOC_XMLFILE` was removed prior to spinning up the DVM daemon as a workaround hack
- set `PRTE_MCA_ras_slurm_use_entire_allocation` to `1` to ensure the DVM system "sees" all available resources